### PR TITLE
make block message more clear

### DIFF
--- a/components/conversation-screen.tsx
+++ b/components/conversation-screen.tsx
@@ -593,7 +593,7 @@ const ConversationScreen = ({navigation, route}) => {
         }}
       >
         {lastMessageStatus === 'timeout' ?  "Message not delivered. Are you online?" : '' }
-        {lastMessageStatus === 'blocked' ?  name + ' is unavailable right now. Try messaging someone else!' : '' }
+        {lastMessageStatus === 'blocked' ?  name + ' has unfortunately restricted who can talk to them, try talking to somebody else!' : '' }
         {lastMessageStatus === 'not unique' ? `Someone already sent that intro! Try sending ${name} a different message...` : '' }
         {lastMessageStatus === 'too long' ? 'That message is too big! 😩' : '' }
       </DefaultText>


### PR DESCRIPTION
instead of just telling the user that the user theyre messaging is "unavailable" (can be messaged in the future), tell them theyre blocked without actually telling them theyre blocked (they dont know the exact reason why the user cant be messaged but they know they cant be messaged, unless they look at the repo and get their heart broken)