### PR TITLE
#269: Use logarithmic scaling for distance selection

### DIFF
--- a/components/labelled-slider.tsx
+++ b/components/labelled-slider.tsx
@@ -2,10 +2,12 @@ import {
   View,
 } from 'react-native';
 import {
+  useMemo,
   useState,
 } from 'react';
 import Slider from '@react-native-community/slider';
 import { DefaultText } from './default-text';
+import { LINEAR_SCALE } from '../scales/scales';
 
 const LabelledSlider = ({label, minimumValue, maximumValue, ...rest}) => {
   const {
@@ -15,19 +17,22 @@ const LabelledSlider = ({label, minimumValue, maximumValue, ...rest}) => {
     style,
     addPlusAtMax,
     valueRewriter = (x) => x,
+    scale: {scaleValue, descaleValue} = LINEAR_SCALE,
     ...rest_
   } = rest;
 
   const [valueState, setValueState] = useState(initialValue);
+  const roundedValue = useMemo(() => Math.round(valueState), [valueState]);
 
   if (value !== undefined && valueState !== value) {
     setValueState(value);
   }
 
   const onValueChange_ = (value_: number) => {
-    setValueState(value_);
+    const scaledValue = scaleValue(value_, minimumValue, maximumValue);
+    setValueState(scaledValue);
     if (onValueChange !== undefined) {
-      onValueChange(value_);
+      onValueChange(Math.round(scaledValue));
     }
   }
 
@@ -44,18 +49,18 @@ const LabelledSlider = ({label, minimumValue, maximumValue, ...rest}) => {
         <Slider
           minimumTrackTintColor="#ddd"
           maximumTrackTintColor="#ddd"
-          minimumValue={minimumValue}
-          maximumValue={maximumValue}
+          minimumValue={descaleValue(minimumValue, minimumValue, maximumValue)}
+          maximumValue={descaleValue(maximumValue, minimumValue, maximumValue)}
           thumbTintColor="#70f"
-          value={valueState}
+          value={descaleValue(valueState, minimumValue, maximumValue)}
           onValueChange={onValueChange_}
           {...rest_}
         />
       </View>
       <View style={{marginTop: 10}} pointerEvents="none">
         <DefaultText>
-          {label}: {valueRewriter(valueState)}
-          {addPlusAtMax && valueState === maximumValue ? '+' : ''}
+          {label}: {valueRewriter(roundedValue)}
+          {addPlusAtMax && roundedValue === maximumValue ? '+' : ''}
         </DefaultText>
       </View>
     </View>

--- a/components/option-screen.tsx
+++ b/components/option-screen.tsx
@@ -201,6 +201,7 @@ const Slider = forwardRef((props: InputProps<OptionGroupSlider>, ref) => {
         step={props.input.slider.step}
         addPlusAtMax={props.input.slider.addPlusAtMax}
         valueRewriter={props.input.slider.valueRewriter}
+        scale={props.input.slider.scale}
         style={{
           marginLeft: 20,
           marginRight: 20,
@@ -686,6 +687,7 @@ const RangeSlider = forwardRef((props: InputProps<OptionGroupRangeSlider>, ref) 
         onLowerValueChange={onLowerValueChange}
         onUpperValueChange={onUpperValueChange}
         valueRewriter={props.input.rangeSlider.valueRewriter}
+        scale={props.input.rangeSlider.scale}
         containerStyle={{
           marginLeft: 20,
           marginRight: 20,

--- a/components/range-slider.tsx
+++ b/components/range-slider.tsx
@@ -22,6 +22,7 @@ const RangeSlider = forwardRef((props: any, ref) => {
     initialLowerValue,
     initialUpperValue,
     valueRewriter,
+    scale,
   } = props;
 
   const args = {
@@ -29,6 +30,7 @@ const RangeSlider = forwardRef((props: any, ref) => {
     maximumValue: maximumValue,
     step: 1,
     valueRewriter: valueRewriter,
+    scale: scale,
   };
 
   const topSliderStyle = useRef({
@@ -82,6 +84,7 @@ const RangeSlider = forwardRef((props: any, ref) => {
         maximumValue={maximumValue}
         step={1}
         valueRewriter={valueRewriter}
+        scale={scale}
         style={topSliderStyle}
       />
       <LabelledSlider
@@ -92,6 +95,7 @@ const RangeSlider = forwardRef((props: any, ref) => {
         maximumValue={maximumValue}
         step={1}
         valueRewriter={valueRewriter}
+        scale={scale}
       />
     </View>
   );

--- a/data/option-groups.tsx
+++ b/data/option-groups.tsx
@@ -18,6 +18,7 @@ import { faPeopleGroup } from '@fortawesome/free-solid-svg-icons/faPeopleGroup'
 import Ionicons from '@expo/vector-icons/Ionicons';
 import { NonNullImageCropperOutput } from '../components/image-cropper';
 import { logout } from '../xmpp/xmpp';
+import { LOGARITHMIC_SCALE, Scale } from "../scales/scales";
 
 type OptionGroupButtons = {
   buttons: {
@@ -104,6 +105,7 @@ type OptionGroupSlider = {
     defaultValue: number,
     valueRewriter?: (v: number) => string,
     currentValue?: number,
+    scale?: Scale,
   }
 };
 
@@ -116,6 +118,7 @@ type OptionGroupRangeSlider = {
     valueRewriter?: (v: number) => string,
     currentMin?: number,
     currentMax?: number,
+    scale?: Scale,
   }
 };
 
@@ -967,6 +970,7 @@ const searchTwoWayBasicsOptionGroups: OptionGroup<OptionGroupInputs>[] = [
         step: 1,
         unitsLabel: 'km',
         addPlusAtMax: true,
+        scale: LOGARITHMIC_SCALE,
         submit: async function(furthestDistance: number | null) {
           const ok = (
             await japi(

--- a/scales/scales.tsx
+++ b/scales/scales.tsx
@@ -1,0 +1,23 @@
+type Scale = {
+  scaleValue: (value: number, min: number, max: number) => number;
+  descaleValue: (scaledValue: number, min: number, max: number) => number;
+};
+
+const LINEAR_SCALE: Scale = {
+  scaleValue: (value) => value,
+  descaleValue: (scaledValue) => scaledValue,
+};
+
+const BASE = 1.5;
+const log = (value: number) => Math.log(value) / Math.log(BASE);
+
+const LOGARITHMIC_SCALE: Scale = {
+  scaleValue: (value, min, max) => Math.pow(BASE, log(min) + ((log(max) - log(min)) / (max - min)) * (value - min)),
+  descaleValue: (scaledValue, min, max) => min + ((log(scaledValue) - log(min)) * (max - min)) / (log(max) - log(min)),
+};
+
+export {
+  Scale,
+  LINEAR_SCALE,
+  LOGARITHMIC_SCALE,
+};


### PR DESCRIPTION
Distance selection now uses logarithmic scaling. I tested different scaling methods and found that logarithmic scaling with a low base value (<= 2.0) gives the best results. Anything under 2.0 as the base value works fine and tweaking it doesn't make much of a diffference, I went with 1.5 as a good middle ground.

Low distances can now be adjusted with a high precision while high distances have a low precision. I think this is fine since the difference between 9900 and 10000 has a lower significance to users than the difference between 100 and 200, for example.

I implemented this in a way that makes it easy to add other scaling methods to sliders, should they be needed. By default, the old behaviour (linear scaling) is used. I decided not to change the age sliders since linear scaling makes more sense there to me.
