### PR TITLE
enhancement: animate scroll only after initial load and remove delay

### DIFF
--- a/components/conversation-screen.tsx
+++ b/components/conversation-screen.tsx
@@ -391,12 +391,13 @@ const ConversationScreen = ({navigation, route}) => {
 
   // Scroll to end when last message changes
   useEffect(() => {
-    (async () => {
-      await delay(500);
-      if (listRef.current) {
+    if (listRef.current) {
+      if(!lastMessageStatus) {
+        listRef.current.scrollToEnd({animated: false});
+      } else {
         listRef.current.scrollToEnd({animated: true});
       }
-    })();
+    } 
   }, [lastMessage?.id]);
 
 


### PR DESCRIPTION
- Modified the scroll animation to trigger only after the initial page load.
- Removed the unnecessary delay that was previously applied to the scroll animation.
- Improved performance by ensuring the scroll animation does not interfere with the initial loading process.

This change enhances user experience by providing a smoother and more immediate interaction with the page content.