### PR TITLE
XMPP improvements

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -305,7 +305,7 @@ const App = () => {
   }, []);
 
   useEffect(() => {
-      ensureLoggedIntoXmpp()
+    ensureLoggedIntoXmpp()
   }, [signedInUser?.personUuid]);
 
   useEffect(() => {

--- a/components/conversation-screen.tsx
+++ b/components/conversation-screen.tsx
@@ -779,7 +779,7 @@ const TextInputWithButton = ({
               }}
             >
               {isLoading &&
-                <ActivityIndicator size="large" color="#70f" />
+                <ActivityIndicator size="small" color="#70f" />
               }
               {!isLoading &&
                 <FontAwesomeIcon

--- a/components/conversation-screen.tsx
+++ b/components/conversation-screen.tsx
@@ -252,6 +252,7 @@ const Menu = ({navigation, name, personId, personUuid, messages, closeFn}) => {
 };
 
 const ConversationScreen = ({navigation, route}) => {
+  const [isOnline, setIsOnline] = useState(lastEvent<boolean>('xmpp-is-online'));
   const [showMenu, setShowMenu] = useState(false);
   const [messageFetchTimeout, setMessageFetchTimeout] = useState(false);
   const [messages, setMessages] = useState<Message[] | null>(null);
@@ -424,6 +425,8 @@ const ConversationScreen = ({navigation, route}) => {
     return listen('xmpp-is-online', maybeFetchFirstPage, messages === null)
   }, [maybeFetchFirstPage, messages]);
 
+  useEffect(() => listen<boolean>('xmpp-is-online', setIsOnline), []);
+
   // Scroll to end when last message changes
   useEffect(() => {
     (async () => {
@@ -481,6 +484,7 @@ const ConversationScreen = ({navigation, route}) => {
           style={{
             justifyContent: 'center',
             alignItems: 'center',
+            maxWidth: 220,
           }}
         >
           <Image
@@ -501,9 +505,21 @@ const ConversationScreen = ({navigation, route}) => {
               fontWeight: '700',
               fontSize: 20,
             }}
+            numberOfLines={1}
           >
             {name ?? '...'}
           </DefaultText>
+          {!isOnline &&
+            <ActivityIndicator
+              size="small"
+              color="#70f"
+              style={{
+                position: 'absolute',
+                right: -40,
+                top: 3,
+              }}
+            />
+          }
         </Pressable>
         {isAvailableUser &&
           <TopNavBarButton
@@ -523,18 +539,9 @@ const ConversationScreen = ({navigation, route}) => {
           />
         }
       </TopNavBar>
-      {messages === null && !messageFetchTimeout &&
+      {messages === null &&
         <View style={{flexGrow: 1, justifyContent: 'center', alignItems: 'center'}}>
           <ActivityIndicator size="large" color="#70f" />
-        </View>
-      }
-      {messages === null && messageFetchTimeout &&
-        <View style={{flexGrow: 1, justifyContent: 'center', alignItems: 'center'}}>
-          <DefaultText
-            style={{fontFamily: 'Trueno'}}
-          >
-            You’re offline
-          </DefaultText>
         </View>
       }
       {messages !== null &&
@@ -636,10 +643,10 @@ const ConversationScreen = ({navigation, route}) => {
         {lastMessageStatus === 'not unique' ? `Someone already sent that intro! Try sending ${name} a different message...` : '' }
         {lastMessageStatus === 'too long' ? 'That message is too big! 😩' : '' }
       </DefaultText>
-      {!messageFetchTimeout && isAvailableUser &&
+      {isAvailableUser &&
         <TextInputWithButton onPress={onPressSend}/>
       }
-      {!messageFetchTimeout && !isAvailableUser &&
+      {!isAvailableUser &&
         <DefaultText
           style={{
             maxWidth: 600,

--- a/components/conversation-screen.tsx
+++ b/components/conversation-screen.tsx
@@ -334,7 +334,7 @@ const ConversationScreen = ({navigation, route}) => {
     if (fetchedMessages !== 'timeout') {
       // Prevents the list from moving up to the newly added speech bubbles and
       // triggering another fetch
-      if (listRef.current) listRef.current.scrollTo({y: 1, animated: false});
+      if (listRef.current) listRef.current.scrollTo({y: 2, animated: false});
 
       setMessages([...(fetchedMessages ?? []), ...(messages ?? [])]);
 
@@ -347,7 +347,7 @@ const ConversationScreen = ({navigation, route}) => {
     setMessages(msgs => [...(msgs ?? []), msg]);
   }, []);
 
-  const isCloseToTop = ({contentOffset}) => contentOffset.y === 0;
+  const isCloseToTop = ({contentOffset}) => contentOffset.y < 1;
 
   const isAtBottom = ({layoutMeasurement, contentOffset, contentSize}) =>
     layoutMeasurement.height + contentOffset.y >= contentSize.height;

--- a/xmpp/xmpp.tsx
+++ b/xmpp/xmpp.tsx
@@ -438,7 +438,7 @@ const login = async (username: string, password: string) => {
     });
 
     _xmpp.on("offline", async () => {
-      notify('xmpp-is-online', true);
+      notify('xmpp-is-online', false);
     });
 
     _xmpp.on("online", async () => {

--- a/xmpp/xmpp.tsx
+++ b/xmpp/xmpp.tsx
@@ -987,6 +987,11 @@ const refreshInbox = async (): Promise<void> => {
       inbox = mergeInbox(inbox, page);
       notify<Inbox>('inbox', inbox);
     }
+
+    // This code was originally intended to speed up fetching the inbox in the
+    // hope this would be faster, though it's actually slower, so we can stop at
+    // the first (very big) page.
+    break;
   }
 };
 

--- a/xmpp/xmpp.tsx
+++ b/xmpp/xmpp.tsx
@@ -437,9 +437,13 @@ const login = async (username: string, password: string) => {
       }
     });
 
-    _xmpp.on("offline", async () => {
-      notify('xmpp-is-online', false);
-    });
+    _xmpp.on("offline",       () => notify('xmpp-is-online', false));
+    _xmpp.on("connecting",    () => notify('xmpp-is-online', false));
+    _xmpp.on("opening",       () => notify('xmpp-is-online', false));
+    _xmpp.on("closing",       () => notify('xmpp-is-online', false));
+    _xmpp.on("close",         () => notify('xmpp-is-online', false));
+    _xmpp.on("disconnecting", () => notify('xmpp-is-online', false));
+    _xmpp.on("disconnect",    () => notify('xmpp-is-online', false));
 
     _xmpp.on("online", async () => {
       if (_xmpp) {


### PR DESCRIPTION
* Formatting
* Remove unused variable (`messages` passed to `Menu`)
* Use XMPP library's online/offline events instead of timeouts to figure out if the user is connected
* Add an online/offline indicator to conversation screens
* Truncate long names in conversation screens with an ellipsis
* Make `maybeLoadNextPage` a bit more sensitive to scrolling near the top
* Fix issue where the bottom of the conversation screen can disappear when offline
* Make the `ActivityIndicator` on the send message button smaller (and therefore appear more centered)
* Do one fetch instead of two when fetching the inbox
* Remove `MaxListenersExceededWarning` that can happen when refreshing very frequently