### PR TITLE
Attempt to make chat more reliable

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -222,8 +222,12 @@ const App = () => {
   }, []);
 
   const fetchServerStatusState = useCallback(async () => {
-    const response = await fetch(STATUS_URL, {cache: 'no-cache'});
-    if (!response.ok) {
+    let response: Response | null = null
+    try {
+      response = await fetch(STATUS_URL, {cache: 'no-cache'});
+    } catch (e) {};
+
+    if (response === null || !response.ok) {
       // If even the status server is down, things are *very* not-okay. But odds
       // are it can't be contacted because the user has a crappy internet
       // connection. The "You're offline" notice should still provide some

--- a/components/inbox-tab.tsx
+++ b/components/inbox-tab.tsx
@@ -27,7 +27,7 @@ import { TopNavBarButton } from './top-nav-bar-button';
 import { inboxOrder, inboxSection } from '../kv-storage/inbox';
 import { signedInUser } from '../App';
 import { Notice } from './notice';
-import { listen } from '../events/events';
+import { listen, lastEvent } from '../events/events';
 
 const Stack = createNativeStackNavigator();
 
@@ -311,21 +311,10 @@ const InboxTab_ = ({navigation}) => {
 
   return (
     <SafeAreaView style={styles.safeAreaView}>
-      <TopNavBar>
-        <DefaultText
-          style={{
-            fontWeight: '700',
-            fontSize: 20,
-          }}
-        >
-          {'Inbox' + (showArchive ? ' (Archive)' : '')}
-        </DefaultText>
-        <TopNavBarButton
-          onPress={onPressArchiveButton}
-          iconName={showArchive ? 'chatbubbles-outline' : 'file-tray-full-outline'}
-          style={{right: 15}}
-        />
-      </TopNavBar>
+      <InboxTabNavBar
+        showArchive={showArchive}
+        onPressArchiveButton={onPressArchiveButton}
+      />
       {inbox === null &&
         <View style={{height: '100%', justifyContent: 'center', alignItems: 'center'}}>
           <ActivityIndicator size="large" color="#70f" />
@@ -346,6 +335,48 @@ const InboxTab_ = ({navigation}) => {
         />
       }
     </SafeAreaView>
+  );
+};
+
+const InboxTabNavBar = ({
+  showArchive,
+  onPressArchiveButton,
+}) => {
+  const [isOnline, setIsOnline] = useState(lastEvent('xmpp-is-online') ?? false);
+
+  useEffect(() => {
+    return listen('xmpp-is-online', setIsOnline);
+  }, []);
+
+  return (
+      <TopNavBar>
+        <View>
+          <DefaultText
+            style={{
+              fontWeight: '700',
+              fontSize: 20,
+            }}
+          >
+            {'Inbox' + (showArchive ? ' (Archive)' : '')}
+          </DefaultText>
+          {!isOnline &&
+            <ActivityIndicator
+              size="small"
+              color="#70f"
+              style={{
+                position: 'absolute',
+                right: -40,
+                top: 3,
+              }}
+            />
+          }
+        </View>
+        <TopNavBarButton
+          onPress={onPressArchiveButton}
+          iconName={showArchive ? 'chatbubbles-outline' : 'file-tray-full-outline'}
+          style={{right: 15}}
+        />
+      </TopNavBar>
   );
 };
 

--- a/components/stream-error-modal.tsx
+++ b/components/stream-error-modal.tsx
@@ -1,4 +1,5 @@
 import {
+  Platform,
   Text,
   View,
 } from 'react-native';
@@ -17,6 +18,10 @@ const StreamErrorModal = () => {
   if (!showError) {
     return <></>;
   };
+
+  if (Platform.OS !== 'web') {
+    return <></>;
+  }
 
   return (
     <View

--- a/xmpp/xmpp.tsx
+++ b/xmpp/xmpp.tsx
@@ -24,10 +24,7 @@ import { AppState, AppStateStatus } from 'react-native';
 const messageTimeout = 10000;
 const fetchConversationTimeout = 15000;
 const fetchInboxTimeout = 30000;
-const pingTimeout = 5000; // TODO
-
-// TODO What happens if the app is offline?
-// TODO What happens if the server is offline?
+const pingTimeout = 5000;
 
 const _xmpp: {
   current: {
@@ -504,7 +501,6 @@ const login = async (username: string, password: string) => {
 
     await _xmpp.current.client.start();
   } catch (e) {
-    _xmpp.current = null;
     notify('xmpp-is-online', false);
 
     console.error(e);
@@ -608,8 +604,6 @@ const sendMessage = async (
   recipientPersonUuid: string,
   message: string,
 ): Promise<MessageStatus> => {
-  console.log('sendMessage'); // TODO
-
   const __sendMessage = new Promise(
     (resolve: (messageStatus: MessageStatus) => void) =>
       _sendMessage(recipientPersonUuid, message, resolve)
@@ -844,8 +838,6 @@ const fetchConversation = async (
   withPersonUuid: string,
   beforeId: string = '',
 ): Promise<Message[] | undefined | 'timeout'> => {
-  console.log('fetchConversation'); // TODO
-
   const __fetchConversation = new Promise(
     (resolve: (messages: Message[] | undefined | 'timeout') => void) =>
       _fetchConversation(withPersonUuid, resolve, beforeId)
@@ -999,8 +991,6 @@ const fetchInboxPage = async (
   endTimestamp: Date | null = null,
   pageSize: number | null = null,
 ): Promise<Inbox | undefined | 'timeout'> => {
-  console.log('fetchInboxPage'); // TODO
-
   const __fetchInboxPage = new Promise(
     (resolve: (inbox: Inbox | undefined) => void) =>
       _fetchInboxPage(resolve, endTimestamp, pageSize)
@@ -1046,12 +1036,9 @@ const logout = async () => {
     return;
   }
 
-  const currentClient = _xmpp.current.client;
-  _xmpp.current = null;
-
   notify('xmpp-is-online', false);
-  await currentClient.reconnect.stop();
-  await currentClient.stop().catch(console.warn);
+  await _xmpp.current.client.reconnect.stop();
+  await _xmpp.current.client.stop().catch(console.warn);
   notify('inbox', null);
   _xmpp.current =  null;
 };
@@ -1069,16 +1056,12 @@ const registerPushToken = async (token: string | null) => {
 };
 
 const _pingServer = (resolve: (result: Pong | null | 'timeout') => void) => {
-  console.log('_pingServer'); // TODO
-
   if (!_xmpp.current) {
-    console.log('_pingServer: no current'); // TODO
     resolve(null);
     return;
   }
 
   if (_xmpp.current.client.status !== 'online') {
-    console.log('_pingServer: status', _xmpp.current.client.status); // TODO
     resolve(null);
     return;
   }
@@ -1174,8 +1157,6 @@ const withReconnectOnTimeout = async <T,>(ms: number, promise: Promise<T>): Prom
 };
 
 const onChangeAppState = (state: AppStateStatus) => {
-  console.log('state', state); // TODO
-
   if (state === 'active') {
     pingServer();
   }

--- a/xmpp/xmpp.tsx
+++ b/xmpp/xmpp.tsx
@@ -496,7 +496,7 @@ const login = async (
 
       notify('xmpp-is-online', true);
 
-      await refreshInbox();
+      refreshInbox();
 
       await registerForPushNotificationsAsync();
     });

--- a/xmpp/xmpp.tsx
+++ b/xmpp/xmpp.tsx
@@ -448,9 +448,7 @@ const login = async (
   username: string,
   password: string,
 ) => {
-  console.log('login'); // TODO
   if (_xmpp.current) {
-    console.log('login: returning early; already logged in'); // TODO
     return; // Already logged in
   }
 
@@ -1044,9 +1042,7 @@ const refreshInbox = async (): Promise<void> => {
 };
 
 const logout = async () => {
-  console.log('logout'); // TODO
   if (!_xmpp.current) {
-    console.log('logout: returning early; no current'); // TODO
     return;
   }
 
@@ -1086,8 +1082,6 @@ const _pingServer = (resolve: (result: Pong | null | 'timeout') => void) => {
     resolve(null);
     return;
   }
-
-  console.log('pinging server'); // TODO
 
   const listenerRemovers: (() => void)[] = [];
 
@@ -1159,7 +1153,6 @@ const pingServerForever = async () => {
 
 const recreateChatClient = async () => {
   if (!_xmpp.current) {
-    console.log('recreateChatClient: no current; returning early'); // TODO
     return; // No current session to recreate
   };
 
@@ -1167,7 +1160,6 @@ const recreateChatClient = async () => {
     // If we're already attempting to reconnect, we don't want to interrupt that
     // attempt, otherwise we risk creating two streams at once and triggering
     // the exception "conflict - Replaced by new connection"
-    console.log('recreateChatClient: reconnecting; returning early'); // TODO
     return;
   }
 
@@ -1192,8 +1184,6 @@ const withReconnectOnTimeout = async <T,>(ms: number, promise: Promise<T>): Prom
   const result = await withTimeout(ms, promise);
 
   removeInputListener();
-
-  console.log('timeout, recievedAnyInput', result === 'timeout', recievedAnyInput); // TODO
 
   if (result === 'timeout' && !recievedAnyInput) {
     recreateChatClient();

--- a/xmpp/xmpp.tsx
+++ b/xmpp/xmpp.tsx
@@ -436,6 +436,10 @@ const login = async (username: string, password: string) => {
 
     _xmpp.current = client(options);
 
+    // The default is 1 second. We set it to 3 seconds here, but it's a shame
+    // xmpp.js doesn't support exponential backoff
+    _xmpp.current.reconnect.delay = 3 * 1000;
+
     _xmpp.current.on("error", (err) => {
       console.error(err);
       if (err.message === "conflict - Replaced by new connection") {


### PR DESCRIPTION
I suspect that this issue is partly to blame for the poor reliability of chat in Duolicious: https://github.com/xmppjs/xmpp.js/issues/902 I also suspect that the Duolicious chat server's reliability is poor.

In any case, we can probably just add some retries and recreate chat clients when the server comes out of the inactive state.

Changes:

* Increase reconnection delay - This prevents clients from DDoSing the server when it goes down then comes back online. Ideally the XMPP library we use (xmpp.js) would support exponential back-off, but it doesn't.

* Recreate the xmpp.js client when the app comes out of the background state on mobile.

* Show a spinner on the inbox tab when temporarily offline

* Use an application-level ping mechanism to determine if the server can be contacted. This should be supported at the transport later seeing as we use websockets. Though [some random Stack Exchange post](https://stackoverflow.com/questions/10585355/sending-websocket-ping-pong-frame-from-browser) said there's inconsistency between the behavior of different browsers with respect to websocket pings.