### PR TITLE
Don't use `Image.getSize`

### DIFF
--- a/components/images.tsx
+++ b/components/images.tsx
@@ -209,6 +209,8 @@ const UserImage = ({
         'image-cropper-open',
         {
           base64: base64Uri,
+          height,
+          width,
           callback: imageCropperCallback,
           showProtip: showProtip,
         }


### PR DESCRIPTION
`Image.getSize` lies sometimes. Worryingly, this issue appears to have been reported to the React Native dev team a few times since 2018, yet no fix is forthcoming: https://github.com/facebook/react-native/issues/22145, https://github.com/facebook/react-native/issues/33498.

Closes https://github.com/duolicious/duolicious-frontend/issues/417.