### PR TITLE
Remove RevenueCat

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,6 @@
         "react-native": "0.74.5",
         "react-native-dropdown-picker": "^5.4.4",
         "react-native-feather": "^1.1.2",
-        "react-native-purchases": "^8.1.0",
         "react-native-safe-area-context": "4.10.5",
         "react-native-screens": "3.31.1",
         "react-native-svg": "15.2.0",
@@ -6442,12 +6441,6 @@
       "version": "9.5.5",
       "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.5.5.tgz",
       "integrity": "sha512-7I/qY8H7Enwasxr4jU6WmtNK+RZ4Z/XvSlDvjXFVe7ii1x0MoSlkw6pD7xuac8qrHQRm9BTcbZNyeeKApYsvCg=="
-    },
-    "node_modules/@revenuecat/purchases-typescript-internal": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal/-/purchases-typescript-internal-13.1.0.tgz",
-      "integrity": "sha512-rWG1KBQISQa6n7eiTIm6PutAwdi6/CMZ9gStNdD+G+BBP5AH/6xwAqEslO75/ARzDlT8gLITP8dgtaqQKGBi2Q==",
-      "license": "MIT"
     },
     "node_modules/@rneui/base": {
       "version": "4.0.0-rc.7",
@@ -14445,23 +14438,6 @@
         "react-native-svg": ">=5.3"
       }
     },
-    "node_modules/react-native-purchases": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-purchases/-/react-native-purchases-8.1.0.tgz",
-      "integrity": "sha512-9v5KFhNgg8+PJyrJeoEcL2pZtymufs0u5DwuLR3A/n+QWaTO7/XdrfL5pvwxrWfhArWf45ODRb36oAe3X/8w9Q==",
-      "license": "MIT",
-      "workspaces": [
-        "examples/purchaseTesterTypescript",
-        "react-native-purchases-ui"
-      ],
-      "dependencies": {
-        "@revenuecat/purchases-typescript-internal": "13.1.0"
-      },
-      "peerDependencies": {
-        "react": ">= 16.6.3",
-        "react-native": "*"
-      }
-    },
     "node_modules/react-native-ratings": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/react-native-ratings/-/react-native-ratings-8.1.0.tgz",
@@ -21531,11 +21507,6 @@
       "resolved": "https://registry.npmjs.org/@react-spring/types/-/types-9.5.5.tgz",
       "integrity": "sha512-7I/qY8H7Enwasxr4jU6WmtNK+RZ4Z/XvSlDvjXFVe7ii1x0MoSlkw6pD7xuac8qrHQRm9BTcbZNyeeKApYsvCg=="
     },
-    "@revenuecat/purchases-typescript-internal": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@revenuecat/purchases-typescript-internal/-/purchases-typescript-internal-13.1.0.tgz",
-      "integrity": "sha512-rWG1KBQISQa6n7eiTIm6PutAwdi6/CMZ9gStNdD+G+BBP5AH/6xwAqEslO75/ARzDlT8gLITP8dgtaqQKGBi2Q=="
-    },
     "@rneui/base": {
       "version": "4.0.0-rc.7",
       "resolved": "https://registry.npmjs.org/@rneui/base/-/base-4.0.0-rc.7.tgz",
@@ -27557,14 +27528,6 @@
       "resolved": "https://registry.npmjs.org/react-native-feather/-/react-native-feather-1.1.2.tgz",
       "integrity": "sha512-qBc0+XegKkX4JV6ykgScasguEV3RdlbYp9IrCMnbozngOgJ7vi76pyRpb+dnZ1AZVkYsbYnpdA9JXeP7EJbMCA==",
       "requires": {}
-    },
-    "react-native-purchases": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/react-native-purchases/-/react-native-purchases-8.1.0.tgz",
-      "integrity": "sha512-9v5KFhNgg8+PJyrJeoEcL2pZtymufs0u5DwuLR3A/n+QWaTO7/XdrfL5pvwxrWfhArWf45ODRb36oAe3X/8w9Q==",
-      "requires": {
-        "@revenuecat/purchases-typescript-internal": "13.1.0"
-      }
     },
     "react-native-ratings": {
       "version": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
     "react-native": "0.74.5",
     "react-native-dropdown-picker": "^5.4.4",
     "react-native-feather": "^1.1.2",
-    "react-native-purchases": "^8.1.0",
     "react-native-safe-area-context": "4.10.5",
     "react-native-screens": "3.31.1",
     "react-native-svg": "15.2.0",


### PR DESCRIPTION
I might add it back later if the funding situation gets dire, but web users are covering server costs for now. Besides, the extra dependency increases the app's download size, and I don't like Google Play indicating that Duolicious has in-app purchases, when it should be more accurately described as an in-app donation method (which hasn't been implemented anyway).