### PR TITLE
UI rough edges

### DIFF
--- a/components/avatar.tsx
+++ b/components/avatar.tsx
@@ -4,6 +4,7 @@ import {
 } from 'react';
 import {
   Pressable,
+  StyleSheet,
   View,
 } from 'react-native';
 import { DefaultText } from './default-text';
@@ -61,13 +62,13 @@ const Avatar = ({percentage, ...props}) => {
       style={elementStyle}
     >
       <ImageBackground
-        source={imageUuid && {
+        source={imageUuid ? {
           uri: `${IMAGES_URL}/450-${imageUuid}.jpg`,
           height: 450,
           width: 450,
-        }}
+        } : undefined}
         placeholder={imageBlurhash && { blurhash: imageBlurhash }}
-        transition={150}
+        transition={!imageUuid ? { duration: 0, effect: null } : 150}
         style={{
           flex: 1,
           aspectRatio: 1,
@@ -75,14 +76,23 @@ const Avatar = ({percentage, ...props}) => {
           overflow: 'hidden',
           justifyContent: 'center',
           alignItems: 'center',
-          backgroundColor: '#f1e5ff',
+          backgroundColor: imageBlurhash ? undefined : '#f1e5ff',
           margin: 4,
         }}
       >
-        {!imageUuid &&
+        {!imageUuid && !imageBlurhash &&
           <Ionicons
             style={{fontSize: 40, color: 'rgba(119, 0, 255, 0.2)'}}
             name={'person'}
+          />
+        }
+        {verificationRequired &&
+          <View
+            style={{
+              ...StyleSheet.absoluteFillObject,
+              zIndex: 999,
+              backgroundColor: 'rgba(255, 255, 255, 0.7)',
+            }}
           />
         }
       </ImageBackground>
@@ -99,6 +109,7 @@ const Avatar = ({percentage, ...props}) => {
           backgroundColor: '#70f',
           alignItems: 'center',
           justifyContent: 'center',
+          overflow: 'hidden',
         }}
       >
         <DefaultText
@@ -111,6 +122,16 @@ const Avatar = ({percentage, ...props}) => {
         >
           {percentage}%
         </DefaultText>
+        {verificationRequired &&
+          <View
+            style={{
+              ...StyleSheet.absoluteFillObject,
+              zIndex: 999,
+              backgroundColor: 'rgba(255, 255, 255, 0.7)',
+            }}
+          >
+          </View>
+        }
       </View>
       {isSkipped &&
         <View
@@ -136,15 +157,11 @@ const Avatar = ({percentage, ...props}) => {
       {verificationRequired &&
         <View
           style={{
-            position: 'absolute',
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0,
-            backgroundColor: 'rgba(255, 255, 255, 0.8)',
+            ...StyleSheet.absoluteFillObject,
             justifyContent: 'center',
             alignItems: 'center',
             gap: 5,
+            borderRadius: 999,
           }}
         >
           <FontAwesomeIcon

--- a/components/base-quiz-card.tsx
+++ b/components/base-quiz-card.tsx
@@ -14,6 +14,7 @@ import {
 import {
   Dimensions,
   PanResponder,
+  Platform,
   RegisteredStyle,
   StyleProp,
   View,
@@ -161,9 +162,15 @@ const animateOut = async (gesture, setSpringTarget, dir?: Direction) => {
 }
 
 const animateBack = (setSpringTarget) => {
-  // translate back to the initial position
+  // translate/rotate back to the initial position
   return new Promise((resolve) => {
-    setSpringTarget.current[0].start({ x: 0, y: 0, rot: 0, config: physics.animateBack, onRest: resolve })
+    setSpringTarget.current[0].start({
+      x: 0,
+      y: 0,
+      rot: 0,
+      config: physics.animateBack,
+      onResolve: resolve,
+    })
   })
 }
 
@@ -294,8 +301,11 @@ const BaseQuizCard = forwardRef(
           (evt, gestureState) => !isAnimating.current,
         onMoveShouldSetPanResponderCapture:
           (evt, gestureState) => !isAnimating.current,
-
         onPanResponderGrant: (evt, gestureState) => {
+          if (Platform.OS === 'web') {
+            evt.preventDefault?.();
+          }
+
           // The gesture has started.
           // Probably wont need this anymore as position relative to swipe!
           setSpringTarget.current[0].start({
@@ -306,6 +316,10 @@ const BaseQuizCard = forwardRef(
           })
         },
         onPanResponderMove: (evt, gestureState) => {
+          if (Platform.OS === 'web') {
+            evt.preventDefault?.();
+          }
+
           // use guestureState.vx / guestureState.vy for velocity calculations
           // translate element
           setSpringTarget.current[0].start({


### PR DESCRIPTION
This fixes two UI/UX bugs:

* c2ef06e2b4f59c7b8b5751f3f0d65538593f97c8 - The `Verify your {verificationRequired} to unlock` message on the Q&A tab appeared on an opaque, square background which didn't line up with the circular avatars it on which is was overlaid. This issue was evident when a Q&A card would move underneath the Avatar.

* 16aa08962544a0e2d1cfa7d4a2ccd33672ed1d59 - The quiz cards would sometimes freeze. There might still be some ways to make the quiz cards freeze, but one underlying issue is that there's an `isAnimating` ref designed to prevent user interaction which wasn't getting reset sometimes. This happened when there was only a very small amount of movement in the quiz card stack. I suspect high DPI devices are worst-affected; There's been a long-lived and steady stream of complaints from Android users that the quiz card stack freezes. Hopefully this goes a long way to address that.