### PR TITLE
Fix report modal bug

### DIFF
--- a/components/deafult-modal.tsx
+++ b/components/deafult-modal.tsx
@@ -1,0 +1,129 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  Animated,
+  BackHandler,
+  Easing,
+  Platform,
+  StatusBar,
+  StyleSheet,
+  View,
+  useWindowDimensions,
+} from 'react-native';
+
+/*
+ * React Native has a `Modal` element but it has a bug on Android
+ */
+
+const DefaultModal = ({
+  visible,
+  transparent,
+  onRequestClose,
+  children
+}: {
+  visible: boolean
+  transparent: boolean
+  onRequestClose?: () => void,
+  children: React.ReactNode
+}) => {
+  const { width, height } = useWindowDimensions();
+  // Track whether the modal should be mounted in the tree
+  const [isMounted, setIsMounted] = useState(visible);
+
+  // Opacity value for the fade animation
+  const opacity = useRef(new Animated.Value(0)).current;
+
+  // Whenever `visible` changes, run the fade in/out animation
+  useEffect(() => {
+    if (visible) {
+      setIsMounted(true);
+      Animated.timing(opacity, {
+        toValue: 1,
+        duration: 250,
+        useNativeDriver: true,
+        easing: Easing.linear,
+      }).start();
+    } else {
+      Animated.timing(opacity, {
+        toValue: 0,
+        duration: 250,
+        useNativeDriver: true,
+        easing: Easing.linear,
+      }).start(({ finished }) => {
+        if (finished) {
+          setIsMounted(false);
+        }
+      });
+    }
+  }, [visible, opacity]);
+
+  // Handle the hardware back button on Android
+  useEffect(() => {
+    const onBackPress = () => {
+      // If the modal is currently visible, we call onRequestClose
+      // and intercept the default back action.
+      if (isMounted) {
+        onRequestClose?.();
+        return true;
+      }
+      return false;
+    };
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+
+    return () => {
+      subscription.remove();
+    };
+  }, [isMounted, onRequestClose]);
+
+  // If not visible, we completely remove it from the render tree
+  if (!isMounted) {
+    return null;
+  }
+
+  return (
+    <View
+      style={[
+        {
+          width,
+          height: height + (StatusBar?.currentHeight ?? 0),
+        },
+        styles.wrapper
+      ]}
+      pointerEvents={visible ? 'auto' : 'none'}
+    >
+      {/* Animated container to handle the 'fade' effect */}
+      <Animated.View
+        style={[
+          styles.container,
+          {
+            backgroundColor: transparent ? 'transparent' : 'white',
+            opacity,
+          }
+        ]}
+      >
+        {/* Your modal content goes here */}
+        {children}
+      </Animated.View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  wrapper: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: 0,
+    right: 0,
+    zIndex: 9999,
+    backgroundColor: 'transparent',
+  },
+  container: {
+    ...StyleSheet.absoluteFillObject,
+  },
+});
+
+export {
+  DefaultModal
+};
+

--- a/components/donation-nag-modal.tsx
+++ b/components/donation-nag-modal.tsx
@@ -1,7 +1,6 @@
 import {
   Animated,
   Linking,
-  Modal,
   Platform,
   View,
 } from 'react-native';
@@ -16,6 +15,7 @@ import { signedInUser } from '../App';
 import { api } from '../api/api';
 import { getRandomElement } from '../util/util';
 import * as _ from "lodash";
+import { DefaultModal } from './deafult-modal';
 
 const gagLocations = _.shuffle([
   '/a/',
@@ -167,12 +167,7 @@ const MarketingDonationNagModalWeb = ({
   };
 
   return (
-    <Modal
-      animationType="fade"
-      transparent={true}
-      visible={isVisible}
-      statusBarTranslucent={true}
-    >
+    <DefaultModal visible={isVisible} transparent={true}>
       <View
         style={{
           width: '100%',
@@ -298,7 +293,7 @@ const MarketingDonationNagModalWeb = ({
           </View>
         </View>
       </View>
-    </Modal>
+    </DefaultModal>
   );
 };
 

--- a/components/report-modal.tsx
+++ b/components/report-modal.tsx
@@ -1,5 +1,4 @@
 import {
-  Modal,
   Pressable,
   View,
   Platform,
@@ -18,6 +17,7 @@ import { X } from "react-native-feather";
 import { listen } from '../events/events';
 import { setSkipped } from '../hide-and-block/hide-and-block';
 import { KeyboardDismissingView } from './keyboard-dismissing-view';
+import { DefaultModal } from './deafult-modal';
 
 type ReportModalInitialData = {
   name: string
@@ -113,13 +113,7 @@ const ReportModal = () => {
   }, [isTooFewChars, isSomethingWrong]);
 
   return (
-    <Modal
-      animationType="fade"
-      transparent={false}
-      visible={isVisible}
-      onRequestClose={close}
-      statusBarTranslucent={true}
-    >
+    <DefaultModal visible={isVisible} transparent={false} onRequestClose={close}>
       <KeyboardDismissingView
         style={{
           width: '100%',
@@ -229,7 +223,7 @@ const ReportModal = () => {
           </View>
         </View>
       </KeyboardDismissingView>
-    </Modal>
+    </DefaultModal>
   );
 }
 


### PR DESCRIPTION
The report modal stopped displaying properly in Android recently. I didn't bother tracking down the commit where the regression was introduced, though https://github.com/facebook/react-native/issues/48611 might be the cause; I wrote my own `Modal` and it seems to work fine now :man_shrugging: