### PR TITLE
Card stack bug squashing

### DIFF
--- a/api/api.tsx
+++ b/api/api.tsx
@@ -122,6 +122,7 @@ const japi = async (
   maxRetries?: number,
   showValidationToast?: boolean,
 ): Promise<ApiResponse> => {
+  console.log(method, endpoint, body); // TODO
   const init = body === undefined ? {} : {
     headers: {
       Accept: 'application/json',

--- a/api/api.tsx
+++ b/api/api.tsx
@@ -122,7 +122,6 @@ const japi = async (
   maxRetries?: number,
   showValidationToast?: boolean,
 ): Promise<ApiResponse> => {
-  console.log(method, endpoint, body); // TODO
   const init = body === undefined ? {} : {
     headers: {
       Accept: 'application/json',

--- a/components/base-quiz-card.tsx
+++ b/components/base-quiz-card.tsx
@@ -33,8 +33,6 @@ type CardLeftScreenHandler = (direction: Direction) => void
 type SwipeRequirementFufillUpdate = (direction: Direction) => void
 type SwipeRequirementUnfufillUpdate = () => void
 
-// TODO: Tried to modify key `swipeThreshold` of an object which has been already passed to a worklet. See
-
 interface API {
   /**
    * Programmatically trigger a swipe of the card in one of the valid directions `'left'`, `'right'`, `'up'` and `'down'`. This function, `swipe`, can be called on a reference of the BaseQuizCard instance.

--- a/components/base-quiz-card.tsx
+++ b/components/base-quiz-card.tsx
@@ -188,8 +188,8 @@ const animateBack = (
 }
 
 const getSwipeDirection = (
-  property,
-  swipeThreshold = settings.swipeThreshold
+  property: { x: number, y: number },
+  swipeThreshold: number,
 ): Direction => {
   'worklet';
 
@@ -313,8 +313,6 @@ const BaseQuizCard = forwardRef(
     // We'll store an array with a single object that has .start(...) to match your usage
     const setSpringTarget = useRef({ start: createSpringStarter(x, y, rot) });
 
-    settings.swipeThreshold = swipeThreshold;
-
     useImperativeHandle(ref, () => ({
       async swipe (dir: Direction = 'right') {
         if (!isAtStartPosition.current) return;
@@ -348,10 +346,10 @@ const BaseQuizCard = forwardRef(
         gesture
       ) => {
         // Check if this is a swipe
-        const dir = getSwipeDirection({
-          x: gesture.dx,
-          y: gesture.dy,
-        });
+        const dir = getSwipeDirection(
+          { x: gesture.dx, y: gesture.dy },
+          swipeThreshold
+        );
 
         if (dir === 'none' || preventSwipe.includes(dir)) {
           // Card was not flicked away, animate back to start

--- a/components/button/centered-text.tsx
+++ b/components/button/centered-text.tsx
@@ -34,18 +34,20 @@ const ButtonWithCenteredText = (props) => {
   const animatedOpacity = useRef(new Animated.Value(1)).current;
 
   const fade = (callback?: () => void) => {
-    animatedOpacity.stopAnimation();
-    animatedOpacity.setValue(opacityLo);
+    animatedOpacity.stopAnimation(() =>
+      animatedOpacity.setValue(opacityLo)
+    );
     callback && callback();
   };
 
   const unfade = (callback?: () => void) => {
-    animatedOpacity.stopAnimation();
-    Animated.timing(animatedOpacity, {
-      toValue: opacityHi,
-      duration: 1000,
-      useNativeDriver: true,
-    }).start((result) => result.finished && callback && callback());
+    animatedOpacity.stopAnimation(() =>
+      Animated.timing(animatedOpacity, {
+        toValue: opacityHi,
+        duration: 1000,
+        useNativeDriver: true,
+      }).start((result) => result.finished && callback && callback())
+    );
   };
 
   class Api {
@@ -80,12 +82,19 @@ const ButtonWithCenteredText = (props) => {
         height: 50,
         ...containerStyle,
       }}
-      onPressIn={
-        () => isEnabledRef.current && fade()}
-      onPressOut={
-        () => isEnabledRef.current && unfade()}
-      onPress={
-        () => isEnabledRef.current && !loading && onPress && onPress()}
+      onPressIn={() => {
+        if (isEnabledRef.current) {
+          fade();
+        }
+      }}
+      onPressOut={() => {
+        if (isEnabledRef.current) {
+          unfade();
+        }
+        if (isEnabledRef.current && !loading && onPress) {
+          onPress();
+        }
+      }}
     >
       <Animated.View
         style={{


### PR DESCRIPTION
* Fixes #593
* Fixes a regression re-introduced by #591, where users can "catch" a card as it's leaving the screen. This causes the logic and UI to lose sync when answering Q&A questions, resulting in users ostensibly answering one question, but having the app POST it as a response to another question.