### PR TITLE
fix: ensure dragged photos are on top of other elements

### DIFF
--- a/components/images/images.tsx
+++ b/components/images/images.tsx
@@ -984,9 +984,11 @@ const SlotRow = ({
 };
 
 const Images = ({
-  input
+  input,
+  style,
 }: {
-  input: OptionGroupPhotos
+  input: OptionGroupPhotos,
+  style: object,
 }) => {
   const viewRef = useRef<View>(null);
   const [, setLayoutChanged] = useState({});
@@ -1101,6 +1103,7 @@ const Images = ({
       style={{
         padding: 10,
         gap: 10,
+        ...style
       }}
     >
       <FirstSlotRow firstFileNumber={1} />

--- a/components/profile-tab.tsx
+++ b/components/profile-tab.tsx
@@ -171,7 +171,7 @@ const Images_ = ({data}) => {
 
   return (
     <>
-      <Images input={input} />
+      <Images input={input} style={{zIndex: 999}}/> {/* Give high zIndex since images can be dragged over other elements */}
       <DefaultText
         style={{
           color: '#999',


### PR DESCRIPTION
Before this would look awkward, with other text in the same view like "Hold and drag photos" being rendered over the dragged image.

A zIndex of 999 seems arbitrary, but this was also used as a "really high value" in other places already.

Closes #609

---

To do:

- [x] Test in Android
- [x] Test in iOS