### PR TITLE
Fix issue with restoring state

### DIFF
--- a/components/labelled-slider.tsx
+++ b/components/labelled-slider.tsx
@@ -49,7 +49,10 @@ const LabelledSlider = forwardRef(({label, minimumValue, maximumValue, ...rest}:
     style,
     addPlusAtMax,
     valueRewriter = (x) => x,
-    scale: {scaleValue, descaleValue} = LINEAR_SCALE,
+    scale: {
+      scaleValue = LINEAR_SCALE.scaleValue,
+      descaleValue = LINEAR_SCALE.descaleValue,
+    }
   } = rest;
 
   const descaledInitialValue = descaleValue(initialValue, minimumValue, maximumValue);


### PR DESCRIPTION
Steps to reproduce on web (and probably mobile):

1. Navigate to Search tab > Search Filters > Furthest distance.
2. Without closing the 'Furthest Distance' screen, press the 'Inbox' tab. Open a conversation.
3. Refresh. The app should crash.

Upon inspecting local storage, this is in `navigation_state`:

```
...
                        "params": {
                          "optionGroups": [
                            {
                              "title": "Furthest Distance",
                              "description": "How far away can people be?",
                              "input": {
                                "slider": {
                                  "sliderMin": 5,
                                  "sliderMax": 10000,
                                  "defaultValue": 10000,
                                  "step": 1,
                                  "unitsLabel": "km",
                                  "addPlusAtMax": true,
                                  "scale": {},
                                  "currentValue": null
                                }
                              }
                            },
...
```

The important part is `"scale": {}`. It seems not to be getting properly serialized.