### PR TITLE
Fix issue with restoring state again

### DIFF
--- a/components/labelled-slider.tsx
+++ b/components/labelled-slider.tsx
@@ -49,7 +49,10 @@ const LabelledSlider = forwardRef(({label, minimumValue, maximumValue, ...rest}:
     style,
     addPlusAtMax,
     valueRewriter = (x) => x,
-    scale: {scaleValue, descaleValue} = LINEAR_SCALE,
+    scale: {
+      scaleValue = LINEAR_SCALE.scaleValue,
+      descaleValue = LINEAR_SCALE.descaleValue,
+    } = {},
   } = rest;
 
   const descaledInitialValue = descaleValue(initialValue, minimumValue, maximumValue);


### PR DESCRIPTION
I had to revert #670 because it caused the app to break in the case where `scale` was `undefined`. That case is even more common than the error case I was trying to handle.

The app is still broken, though it's less-broken than it was before. The proper solution is to somehow prevent the 'Furthest Distance' screen from making its way into `navigation_state` as described in #670.