### PR TITLE
fix back on mobile web from closing site when in a conversation

### DIFF
--- a/components/conversation-screen/conversation-screen.tsx
+++ b/components/conversation-screen/conversation-screen.tsx
@@ -11,6 +11,7 @@ import {
   TextStyle,
   View,
   ViewStyle,
+  BackHandler,
 } from 'react-native';
 import {
   Fragment,
@@ -622,6 +623,20 @@ const ConversationScreen = ({navigation, route}) => {
   }, [personUuid, isFocused]);
 
   if (Platform.OS === 'web') {
+    // intercept mobile back button on mobile to go back instead of closing the app
+    useEffect(() => {
+      const onBackPress = () => {
+        navigation.navigate(-1);
+        return true;
+      };
+  
+      const backHandler = BackHandler.addEventListener('hardwareBackPress', onBackPress);
+  
+      return () => {
+        backHandler.remove();
+      };
+    }, []);
+
     // eslint-disable-next-line react-hooks/rules-of-hooks
     useEffect(() => {
       const handleFocus = () => {


### PR DESCRIPTION
I also tried to add a "Are you sure you want to leave?" modal when pressing back from a main tab but I don't know react-native and my web solution was either conflicting with app history state management, or your global `popstate` prevent default was catching it