### PR TITLE
Verify via camera rather than direct upload

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -59,7 +59,6 @@ import { useScrollbarStyle } from './components/navigation/scroll-bar-hooks';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ErrorBoundary } from './components/error-boundary';
 import { TooltipListener } from './components/tooltip';
-import { VerificationCamera } from './components/verification-camera'; // TODO
 
 verificationWatcher();
 
@@ -483,7 +482,72 @@ const App = () => {
 
   return (
     <ErrorBoundary onError={onError}>
-      <VerificationCamera />
+      <SafeAreaProvider>
+        <GestureHandlerRootView>
+          {!isLoading && initialState !== undefined &&
+            <NavigationContainer
+              ref={navigationContainerRef}
+              initialState={
+                initialState ?
+                { ...initialState, stale: true } :
+                undefined
+              }
+              onStateChange={onNavigationStateChange}
+              theme={{
+                ...DefaultTheme,
+                colors: {
+                  ...DefaultTheme.colors,
+                  background: 'white',
+                },
+              }}
+              documentTitle={{
+                formatter: () =>
+                  (numUnreadTitle ? `(${numUnreadTitle}) ` : '') + 'Duolicious'
+              }}
+            >
+              <StatusBar
+                translucent={true}
+                backgroundColor="transparent"
+                barStyle="dark-content"
+              />
+              <Stack.Navigator
+                screenOptions={{
+                  headerShown: false,
+                  presentation: 'card',
+                }}
+              >
+                <Tab.Screen
+                  name="Welcome"
+                  component={WelcomeScreen} />
+                <Tab.Screen
+                  name="Home"
+                  component={HomeTabs} />
+                <Tab.Screen
+                  name="Conversation Screen"
+                  component={ConversationScreen} />
+                <Tab.Screen
+                  name="Prospect Profile Screen"
+                  component={ProspectProfileScreen} />
+                <Tab.Screen
+                  name="Invite Screen"
+                  component={InviteScreen} />
+              </Stack.Navigator>
+            </NavigationContainer>
+          }
+          <TooltipListener/>
+          <DonationNagModal
+            name={signedInUser?.name}
+            estimatedEndDate={signedInUser?.estimatedEndDate}
+            visible={signedInUser?.doShowDonationNag}
+          />
+          <ReportModal/>
+          <ImageCropper/>
+          <ColorPickerModal/>
+          <GifPickerModal/>
+          <Toast/>
+        </GestureHandlerRootView>
+        <WebSplashScreen loading={isLoading}/>
+      </SafeAreaProvider>
     </ErrorBoundary>
   );
 };

--- a/App.tsx
+++ b/App.tsx
@@ -59,6 +59,7 @@ import { useScrollbarStyle } from './components/navigation/scroll-bar-hooks';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ErrorBoundary } from './components/error-boundary';
 import { TooltipListener } from './components/tooltip';
+import { VerificationCameraModal } from './components/verification-camera';
 
 verificationWatcher();
 
@@ -545,6 +546,7 @@ const App = () => {
           <ColorPickerModal/>
           <GifPickerModal/>
           <Toast/>
+          <VerificationCameraModal/>
         </GestureHandlerRootView>
         <WebSplashScreen loading={isLoading}/>
       </SafeAreaProvider>

--- a/App.tsx
+++ b/App.tsx
@@ -59,6 +59,7 @@ import { useScrollbarStyle } from './components/navigation/scroll-bar-hooks';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { ErrorBoundary } from './components/error-boundary';
 import { TooltipListener } from './components/tooltip';
+import { VerificationCamera } from './components/verification-camera'; // TODO
 
 verificationWatcher();
 
@@ -482,72 +483,7 @@ const App = () => {
 
   return (
     <ErrorBoundary onError={onError}>
-      <SafeAreaProvider>
-        <GestureHandlerRootView>
-          {!isLoading && initialState !== undefined &&
-            <NavigationContainer
-              ref={navigationContainerRef}
-              initialState={
-                initialState ?
-                { ...initialState, stale: true } :
-                undefined
-              }
-              onStateChange={onNavigationStateChange}
-              theme={{
-                ...DefaultTheme,
-                colors: {
-                  ...DefaultTheme.colors,
-                  background: 'white',
-                },
-              }}
-              documentTitle={{
-                formatter: () =>
-                  (numUnreadTitle ? `(${numUnreadTitle}) ` : '') + 'Duolicious'
-              }}
-            >
-              <StatusBar
-                translucent={true}
-                backgroundColor="transparent"
-                barStyle="dark-content"
-              />
-              <Stack.Navigator
-                screenOptions={{
-                  headerShown: false,
-                  presentation: 'card',
-                }}
-              >
-                <Tab.Screen
-                  name="Welcome"
-                  component={WelcomeScreen} />
-                <Tab.Screen
-                  name="Home"
-                  component={HomeTabs} />
-                <Tab.Screen
-                  name="Conversation Screen"
-                  component={ConversationScreen} />
-                <Tab.Screen
-                  name="Prospect Profile Screen"
-                  component={ProspectProfileScreen} />
-                <Tab.Screen
-                  name="Invite Screen"
-                  component={InviteScreen} />
-              </Stack.Navigator>
-            </NavigationContainer>
-          }
-          <TooltipListener/>
-          <DonationNagModal
-            name={signedInUser?.name}
-            estimatedEndDate={signedInUser?.estimatedEndDate}
-            visible={signedInUser?.doShowDonationNag}
-          />
-          <ReportModal/>
-          <ImageCropper/>
-          <ColorPickerModal/>
-          <GifPickerModal/>
-          <Toast/>
-        </GestureHandlerRootView>
-        <WebSplashScreen loading={isLoading}/>
-      </SafeAreaProvider>
+      <VerificationCamera />
     </ErrorBoundary>
   );
 };

--- a/app.config.ts
+++ b/app.config.ts
@@ -44,6 +44,7 @@ const config: ExpoConfig = {
     appStoreUrl: "https://apps.apple.com/us/app/duolicious-dating-app/id6499066647",
     infoPlist: {
       NSMicrophoneUsageDescription: "This app uses the microphone to capture audio for updating and sharing on your profile.",
+      NSCameraUsageDescription: "This app uses the camera to capture images for verifying your profile.",
       ITSAppUsesNonExemptEncryption: false
     },
   },

--- a/components/option-screen.tsx
+++ b/components/option-screen.tsx
@@ -842,8 +842,6 @@ const VerificationChecker = forwardRef((props: InputProps<OptionGroupVerificatio
   }, []);
 
   useEffect(() => {
-    notify('watch-verification');
-
     return listen<VerificationEvent>(
       'updated-verification',
       onVerificationEvent,

--- a/components/option-screen.tsx
+++ b/components/option-screen.tsx
@@ -43,7 +43,6 @@ import {
   OptionGroupTextLong,
   OptionGroupTextShort,
   OptionGroupThemePicker,
-  OptionGroupVerificationCamera,
   OptionGroupVerificationChecker,
   descriptionStyle,
   isOptionGroupButtons,
@@ -59,7 +58,6 @@ import {
   isOptionGroupTextLong,
   isOptionGroupTextShort,
   isOptionGroupThemePicker,
-  isOptionGroupVerificationCamera,
   isOptionGroupVerificationChecker,
   maxDailySelfies,
   noneFontSize,
@@ -83,7 +81,6 @@ import { listen, notify } from '../events/events';
 import { Title } from './title';
 import { ShowColorPickerEvent } from './modal/color-picker-modal/color-picker-modal';
 import { isMobile } from '../util/util';
-import { VerificationCamera as VerificationCamera_ } from './verification-camera';
 
 type InputProps<T extends OptionGroupInputs> = {
   input: T,
@@ -506,13 +503,6 @@ const Photos = forwardRef((props: InputProps<OptionGroupPhotos>, ref) => {
     </View>
   );
 });
-
-const VerificationCamera = (props: InputProps<OptionGroupVerificationCamera> & { ref: any }) => {
-  // TODO: Use input props
-  return <VerificationCamera_
-    onSubmit={props.input.verificationCamera.submit}
-  />;
-};
 
 const TextLong = forwardRef((props: InputProps<OptionGroupTextLong>, ref) => {
   const [isInvalid, setIsInvalid] = useState(false);
@@ -1260,8 +1250,6 @@ const InputElement = forwardRef((props: InputProps<OptionGroupInputs>, ref) => {
     return <LocationSelector {...{ref, ...props, input: props.input}}/>;
   } else if (isOptionGroupPhotos(props.input)) {
     return <Photos {...{ref, ...props, input: props.input}}/>;
-  } else if (isOptionGroupVerificationCamera(props.input)) {
-    return <VerificationCamera {...{ref, ...props, input: props.input}}/>;
   } else if (isOptionGroupTextLong(props.input)) {
     return <TextLong {...{ref, ...props, input: props.input}}/>;
   } else if (isOptionGroupTextShort(props.input)) {
@@ -1309,7 +1297,6 @@ const OptionScreen = ({navigation, route}) => {
     input,
     scrollView,
     buttonLabel,
-    fullScreen = false,
   } = thisOptionGroup;
 
   if (!input) {
@@ -1375,19 +1362,6 @@ const OptionScreen = ({navigation, route}) => {
       setIsBottom(containerHeight >= contentHeight);
     }
   }, [containerHeight, contentHeight]);
-
-  if (fullScreen) {
-    return <InputElement
-      ref={inputRef}
-      input={input}
-      isLoading={isLoading}
-      setIsLoading={setIsLoading}
-      onSubmitSuccess={_onSubmitSuccess}
-      title={title}
-      showSkipButton={showSkipButton}
-      theme={theme}
-    />;
-  }
 
   return (
     <SafeAreaView

--- a/components/option-screen.tsx
+++ b/components/option-screen.tsx
@@ -74,13 +74,19 @@ import { CheckChip as CheckChip_, CheckChips as CheckChips_ } from './check-chip
 import { faArrowLeft } from '@fortawesome/free-solid-svg-icons/faArrowLeft'
 import { faCaretDown } from '@fortawesome/free-solid-svg-icons/faCaretDown'
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome'
-import { japi } from '../api/api';
+import { japi, api } from '../api/api';
 import { delay } from '../util/util';
 import { KeyboardDismissingView } from './keyboard-dismissing-view';
 import { listen, notify } from '../events/events';
 import { Title } from './title';
 import { ShowColorPickerEvent } from './modal/color-picker-modal/color-picker-modal';
 import { isMobile } from '../util/util';
+import {
+  listenVerificationCameraResult,
+  showVerificationCamera,
+} from './verification-camera';
+import { notifyUpdatedVerification } from '../verification/verification';
+import { useNavigation } from '@react-navigation/native';
 
 type InputProps<T extends OptionGroupInputs> = {
   input: T,
@@ -787,6 +793,7 @@ const VerificationChecker = forwardRef((props: InputProps<OptionGroupVerificatio
   const [numChecks, setNumChecks] = useState(3);
   const [verifiedThings, setVerifiedThings] = useState<string[]>([]);
   const [unverifiedThings, setUnverifiedThings] = useState<string[]>([]);
+  const navigation = useNavigation<any>();
 
   const isDone = status === 'success' || status === 'failure';
 
@@ -847,6 +854,46 @@ const VerificationChecker = forwardRef((props: InputProps<OptionGroupVerificatio
       onVerificationEvent,
     );
 
+  }, []);
+
+  useEffect(() => {
+    return listenVerificationCameraResult(async (photo) => {
+      if (!photo) {
+        navigation.goBack();
+        showVerificationCamera(false);
+        return;
+      }
+
+      const photoSize = Math.min(photo.width, photo.height);
+
+      notifyUpdatedVerification({
+        status: 'uploading-photo',
+        message: 'Uploading photo',
+      });
+
+      showVerificationCamera(false);
+
+      await japi(
+        'post',
+        '/verification-selfie',
+        {
+          base64_file: {
+            position: 1,
+            base64: photo.base64,
+            top:  Math.round((photo.height - photoSize) / 2),
+            left: Math.round((photo.width  - photoSize) / 2),
+          },
+        },
+        {
+          timeout: 2 * 60 * 1000, // 2 minutes
+          showValidationToast: true,
+        }
+      );
+
+      notify('watch-verification');
+
+      await api('post', '/verify', undefined, { maxRetries: 0 });
+    });
   }, []);
 
   const VerificationText = useCallback(({

--- a/components/option-screen.tsx
+++ b/components/option-screen.tsx
@@ -43,6 +43,7 @@ import {
   OptionGroupTextLong,
   OptionGroupTextShort,
   OptionGroupThemePicker,
+  OptionGroupVerificationCamera,
   OptionGroupVerificationChecker,
   descriptionStyle,
   isOptionGroupButtons,
@@ -58,6 +59,7 @@ import {
   isOptionGroupTextLong,
   isOptionGroupTextShort,
   isOptionGroupThemePicker,
+  isOptionGroupVerificationCamera,
   isOptionGroupVerificationChecker,
   maxDailySelfies,
   noneFontSize,
@@ -81,6 +83,7 @@ import { listen, notify } from '../events/events';
 import { Title } from './title';
 import { ShowColorPickerEvent } from './modal/color-picker-modal/color-picker-modal';
 import { isMobile } from '../util/util';
+import { VerificationCamera as VerificationCamera_ } from './verification-camera';
 
 type InputProps<T extends OptionGroupInputs> = {
   input: T,
@@ -503,6 +506,13 @@ const Photos = forwardRef((props: InputProps<OptionGroupPhotos>, ref) => {
     </View>
   );
 });
+
+const VerificationCamera = (props: InputProps<OptionGroupVerificationCamera> & { ref: any }) => {
+  // TODO: Use input props
+  return <VerificationCamera_
+    onSubmit={props.input.verificationCamera.submit}
+  />;
+};
 
 const TextLong = forwardRef((props: InputProps<OptionGroupTextLong>, ref) => {
   const [isInvalid, setIsInvalid] = useState(false);
@@ -1250,6 +1260,8 @@ const InputElement = forwardRef((props: InputProps<OptionGroupInputs>, ref) => {
     return <LocationSelector {...{ref, ...props, input: props.input}}/>;
   } else if (isOptionGroupPhotos(props.input)) {
     return <Photos {...{ref, ...props, input: props.input}}/>;
+  } else if (isOptionGroupVerificationCamera(props.input)) {
+    return <VerificationCamera {...{ref, ...props, input: props.input}}/>;
   } else if (isOptionGroupTextLong(props.input)) {
     return <TextLong {...{ref, ...props, input: props.input}}/>;
   } else if (isOptionGroupTextShort(props.input)) {
@@ -1297,6 +1309,7 @@ const OptionScreen = ({navigation, route}) => {
     input,
     scrollView,
     buttonLabel,
+    fullScreen = false,
   } = thisOptionGroup;
 
   if (!input) {
@@ -1362,6 +1375,19 @@ const OptionScreen = ({navigation, route}) => {
       setIsBottom(containerHeight >= contentHeight);
     }
   }, [containerHeight, contentHeight]);
+
+  if (fullScreen) {
+    return <InputElement
+      ref={inputRef}
+      input={input}
+      isLoading={isLoading}
+      setIsLoading={setIsLoading}
+      onSubmitSuccess={_onSubmitSuccess}
+      title={title}
+      showSkipButton={showSkipButton}
+      theme={theme}
+    />;
+  }
 
   return (
     <SafeAreaView

--- a/components/option-screen.tsx
+++ b/components/option-screen.tsx
@@ -784,7 +784,7 @@ const VerificationChecker = forwardRef((props: InputProps<OptionGroupVerificatio
     | 'failure'
   >('uploading-photo');
   const [message, setMessage] = useState('Loading...');
-  const [numChecks, setNumChecks] = useState(0);
+  const [numChecks, setNumChecks] = useState(3);
   const [verifiedThings, setVerifiedThings] = useState<string[]>([]);
   const [unverifiedThings, setUnverifiedThings] = useState<string[]>([]);
 

--- a/components/profile-tab.tsx
+++ b/components/profile-tab.tsx
@@ -59,7 +59,8 @@ import Ionicons from '@expo/vector-icons/Ionicons';
 import { logout } from '../chat/application-layer';
 import { DetailedVerificationBadges } from './verification-badge';
 import {
-  VerificationEvent,
+  notifyUpdatedVerification,
+  listenUpdatedVerification,
 } from '../verification/verification';
 import { InviteEntrypoint } from './invite';
 import { InvitePicker } from './invite';
@@ -199,10 +200,7 @@ const ProfileTab_ = ({navigation}) => {
 
       setData(response.json);
 
-      notify<VerificationEvent>(
-        'updated-verification',
-        { photos: response.json.photo_verification }
-      );
+      notifyUpdatedVerification({ photos: response.json.photo_verification });
 
       notify<string>('updated-name', response.json.name);
     })();
@@ -498,8 +496,7 @@ const Options = ({ navigation, data }) => {
   }, [triggerRender]);
 
   useEffect(() => {
-    return listen<VerificationEvent>(
-      'updated-verification',
+    return listenUpdatedVerification(
       (v) => {
         if (!v)
           return;

--- a/components/verification-camera.tsx
+++ b/components/verification-camera.tsx
@@ -14,8 +14,6 @@ import { notify, listen } from '../events/events';
 import { japi, api } from '../api/api';
 import { notifyUpdatedVerification } from '../verification/verification';
 
-// TODO: Show an 'uploading' message
-
 const EVENT_KEY_SHOW = 'verification-camera-show';
 
 const showVerificationCamera = (show: boolean) => {
@@ -53,7 +51,7 @@ const VerificationCamera = () => {
 
         notifyUpdatedVerification({
           status: 'uploading-photo',
-          message: 'Uploading photo...',
+          message: 'Uploading photo',
         });
 
         showVerificationCamera(false);

--- a/components/verification-camera.tsx
+++ b/components/verification-camera.tsx
@@ -24,8 +24,8 @@ const VerificationCamera = () => {
   const [permission, requestPermission] = useCameraPermissions();
   const cameraRef = useRef<CameraView>(null);
 
-  const { width, height } = useWindowDimensions();
-  const size = Math.min(width, height);
+  const { width: windowWidth, height: windowHeight } = useWindowDimensions();
+  const windowSize = Math.min(windowWidth, windowHeight);
 
   useEffect(() => {
     if (permission && !permission.granted) {
@@ -49,6 +49,8 @@ const VerificationCamera = () => {
           );
         }
 
+        const photoSize = Math.min(photo.width, photo.height);
+
         notifyUpdatedVerification({
           status: 'uploading-photo',
           message: 'Uploading photo',
@@ -63,8 +65,8 @@ const VerificationCamera = () => {
             base64_file: {
               position: 1,
               base64: photo.base64,
-              top: 0,
-              left: 0,
+              top:  Math.round((photo.height - photoSize) / 2),
+              left: Math.round((photo.width  - photoSize) / 2),
             },
           },
           {
@@ -99,11 +101,10 @@ const VerificationCamera = () => {
 
   return (
     <View style={styles.container}>
-      <View style={{ width: size, height: size }}>
+      <View style={{ width: windowSize, height: windowSize }}>
         <CameraView
           ref={cameraRef}
           facing="front"
-          ratio="1:1"
           zoom={0}
           flash="off"
           mute={true}

--- a/components/verification-camera.tsx
+++ b/components/verification-camera.tsx
@@ -9,8 +9,14 @@ import { CameraView, useCameraPermissions } from 'expo-camera';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome'
 import { DefaultText } from './default-text';
+import { SomethingWentWrongToast } from './toast';
+import { notify } from '../events/events';
 
-const VerificationCamera = () => {
+const VerificationCamera = ({
+  onSubmit,
+}: {
+  onSubmit: (base64: string) => any,
+}) => {
   const [permission, requestPermission] = useCameraPermissions();
   const cameraRef = useRef<CameraView>(null);
 
@@ -29,10 +35,17 @@ const VerificationCamera = () => {
         const photo = await cameraRef.current.takePictureAsync({
           base64: true
         });
+        if (!photo.base64) {
+          throw new Error(
+            'Expected base64 property to be set while taking verification photo'
+          );
+        }
+        onSubmit(photo.base64);
         console.log('Photo captured:', photo);
         // TODO: handle the captured photo
       } catch (err) {
         console.warn('Error capturing photo:', err);
+        notify<React.FC>('toast', SomethingWentWrongToast);
       }
     }
   };

--- a/components/verification-camera.tsx
+++ b/components/verification-camera.tsx
@@ -12,6 +12,7 @@ import { DefaultText } from './default-text';
 import { SomethingWentWrongToast } from './toast';
 import { notify, listen } from '../events/events';
 import { japi, api } from '../api/api';
+import { notifyUpdatedVerification } from '../verification/verification';
 
 // TODO: Show an 'uploading' message
 
@@ -50,7 +51,12 @@ const VerificationCamera = () => {
           );
         }
 
-        showVerificationCamera(false)
+        notifyUpdatedVerification({
+          status: 'uploading-photo',
+          message: 'Uploading photo...',
+        });
+
+        showVerificationCamera(false);
 
         await japi(
           'post',
@@ -68,6 +74,8 @@ const VerificationCamera = () => {
             showValidationToast: true,
           }
         );
+
+        notify('watch-verification');
 
         await api('post', '/verify', undefined, { maxRetries: 0 });
       } catch (err) {
@@ -214,5 +222,6 @@ const styles = StyleSheet.create({
 
 export {
   VerificationCameraModal,
+  notifyUpdatedVerification,
   showVerificationCamera,
 };

--- a/components/verification-camera.tsx
+++ b/components/verification-camera.tsx
@@ -1,0 +1,157 @@
+import { useEffect, useRef } from 'react';
+import {
+  StyleSheet,
+  View,
+  TouchableOpacity,
+  useWindowDimensions,
+} from 'react-native';
+import { CameraView, useCameraPermissions } from 'expo-camera';
+import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
+import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome'
+import { DefaultText } from './default-text';
+
+const VerificationCamera = () => {
+  const [permission, requestPermission] = useCameraPermissions();
+  const cameraRef = useRef<CameraView>(null);
+
+  const { width, height } = useWindowDimensions();
+  const size = Math.min(width, height);
+
+  useEffect(() => {
+    if (permission && !permission.granted) {
+      requestPermission();
+    }
+  }, [permission]);
+
+  const handleTakePhoto = async () => {
+    if (cameraRef.current) {
+      try {
+        const photo = await cameraRef.current.takePictureAsync({
+          base64: true
+        });
+        console.log('Photo captured:', photo);
+        // TODO: handle the captured photo
+      } catch (err) {
+        console.warn('Error capturing photo:', err);
+      }
+    }
+  };
+
+  if (!permission) {
+    return <View style={styles.container} />;
+  }
+
+  if (!permission.granted) {
+    return (
+      <View style={styles.container}>
+        <DefaultText style={styles.message}>
+          We need your permission to show the camera
+        </DefaultText>
+      </View>
+    );
+  }
+
+  return (
+    <View style={styles.container}>
+      <View style={{ width: size, height: size }}>
+        <CameraView
+          ref={cameraRef}
+          facing="front"
+          ratio="1:1"
+          zoom={0}
+          flash="off"
+          mute={true}
+          mirror={false}
+          style={styles.camera}
+        />
+      </View>
+      <View style={styles.controlsContainer}>
+        <TouchableOpacity
+          style={styles.closeButton}
+          onPress={() => { /* hook up later */ }}
+        >
+          <FontAwesomeIcon
+            icon={faTimes}
+            size={28}
+            color="white"
+            style={{
+              // @ts-ignore
+              outline: 'none'
+            }}
+          />
+        </TouchableOpacity>
+
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity style={styles.shutterOuter} onPress={handleTakePhoto}>
+            <View style={styles.shutterInner} />
+          </TouchableOpacity>
+        </View>
+      </View>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: 'black',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  camera: {
+    flex: 1,
+  },
+  controlsContainer: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+  },
+  message: {
+    color: 'white',
+    textAlign: 'center',
+    paddingBottom: 10,
+  },
+  buttonContainer: {
+    flex: 1,
+    flexDirection: 'row',
+    backgroundColor: 'transparent',
+    margin: 40,
+    justifyContent: 'center',
+    alignItems: 'flex-end',
+  },
+  button: {
+    flex: 1,
+    alignSelf: 'flex-end',
+    alignItems: 'center',
+  },
+  text: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    color: 'white',
+  },
+  closeButton: {
+    position: 'absolute',
+    top: 26,
+    left: 26,
+    zIndex: 2,
+  },
+  shutterOuter: {
+    width: 70,
+    height: 70,
+    borderRadius: 40,
+    borderWidth: 4,
+    borderColor: 'white',
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  shutterInner: {
+    width: 50,
+    height: 50,
+    borderRadius: 32,
+    backgroundColor: 'red',
+  },
+});
+
+export { VerificationCamera };

--- a/components/verification-camera/index.tsx
+++ b/components/verification-camera/index.tsx
@@ -8,9 +8,10 @@ import {
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { faTimes } from '@fortawesome/free-solid-svg-icons/faTimes';
 import { FontAwesomeIcon } from '@fortawesome/react-native-fontawesome'
-import { DefaultText } from './default-text';
-import { SomethingWentWrongToast } from './toast';
-import { notify, listen } from '../events/events';
+import { DefaultText } from '../default-text';
+import { SomethingWentWrongToast } from '../toast';
+import { notify, listen } from '../../events/events';
+import { getBestResolution } from './resolution';
 
 const EVENT_KEY_SHOW = 'verification-camera-show';
 const EVENT_KEY_RESULT = 'verification-camera-result';
@@ -37,6 +38,7 @@ const listenVerificationCameraResult = (
 
 const VerificationCamera = () => {
   const [permission, requestPermission] = useCameraPermissions();
+  const [pictureSize, setPictureSize] = useState<string | undefined>();
   const cameraRef = useRef<CameraView>(null);
 
   const { width: windowWidth, height: windowHeight } = useWindowDimensions();
@@ -102,6 +104,12 @@ const VerificationCamera = () => {
           mute={true}
           mirror={false}
           style={styles.camera}
+          pictureSize={pictureSize}
+          onCameraReady={async () => {
+            const availablePictureSizes = await cameraRef.current?.getAvailablePictureSizesAsync();
+            const bestResolution = getBestResolution(availablePictureSizes);
+            setPictureSize(bestResolution ?? undefined);
+          }}
         />
       </View>
       <View style={styles.controlsContainer}>

--- a/components/verification-camera/index.tsx
+++ b/components/verification-camera/index.tsx
@@ -83,35 +83,31 @@ const VerificationCamera = () => {
     return <View style={styles.container} />;
   }
 
-  if (!permission.granted) {
-    return (
-      <View style={styles.container}>
+  return (
+    <View style={styles.container}>
+      {permission?.granted ? (
+        <View style={{ width: windowSize, height: windowSize }}>
+          <CameraView
+            ref={cameraRef}
+            facing="front"
+            zoom={0}
+            flash="off"
+            mute={true}
+            mirror={false}
+            style={styles.camera}
+            pictureSize={pictureSize}
+            onCameraReady={async () => {
+              const availablePictureSizes = await cameraRef.current?.getAvailablePictureSizesAsync();
+              const bestResolution = getBestResolution(availablePictureSizes);
+              setPictureSize(bestResolution ?? undefined);
+            }}
+          />
+        </View>
+      ) : (
         <DefaultText style={styles.message}>
           We need your permission to show the camera
         </DefaultText>
-      </View>
-    );
-  }
-
-  return (
-    <View style={styles.container}>
-      <View style={{ width: windowSize, height: windowSize }}>
-        <CameraView
-          ref={cameraRef}
-          facing="front"
-          zoom={0}
-          flash="off"
-          mute={true}
-          mirror={false}
-          style={styles.camera}
-          pictureSize={pictureSize}
-          onCameraReady={async () => {
-            const availablePictureSizes = await cameraRef.current?.getAvailablePictureSizesAsync();
-            const bestResolution = getBestResolution(availablePictureSizes);
-            setPictureSize(bestResolution ?? undefined);
-          }}
-        />
-      </View>
+      )}
       <View style={styles.controlsContainer}>
         <TouchableOpacity
           style={styles.closeButton}
@@ -128,11 +124,13 @@ const VerificationCamera = () => {
           />
         </TouchableOpacity>
 
-        <View style={styles.buttonContainer}>
-          <TouchableOpacity style={styles.shutterOuter} onPress={handleTakePhoto}>
-            <View style={styles.shutterInner} />
-          </TouchableOpacity>
-        </View>
+        {permission?.granted &&
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity style={styles.shutterOuter} onPress={handleTakePhoto}>
+              <View style={styles.shutterInner} />
+            </TouchableOpacity>
+          </View>
+        }
       </View>
     </View>
   );

--- a/components/verification-camera/resolution.test.tsx
+++ b/components/verification-camera/resolution.test.tsx
@@ -1,0 +1,43 @@
+import { getBestResolution } from './resolution';
+
+describe('getBestResolution', () => {
+  it('returns null when the input list is null', () => {
+    expect(getBestResolution(null)).toBeNull();
+  });
+
+  it('returns null when the input list is undefined', () => {
+    expect(getBestResolution(undefined)).toBeNull();
+  });
+
+  it('returns null when the input list is empty', () => {
+    expect(getBestResolution([])).toBeNull();
+  });
+
+  it('ignores invalid resolution strings and returns null if none are valid', () => {
+    const candidates = ['foo', '1080x', 'x720', '1920-1080'];
+    expect(getBestResolution(candidates)).toBeNull();
+  });
+
+  it('returns the only valid resolution when exactly one entry parses', () => {
+    const candidates = ['foo', '800x600', 'bar'];
+    expect(getBestResolution(candidates)).toBe('800x600');
+  });
+
+  it('uses the default target (900 × 900) when none is supplied', () => {
+    const candidates = ['1024x768', '900x900', '1600x900'];
+    // 900 × 900 is an exact match with error 0, so it should win.
+    expect(getBestResolution(candidates)).toBe('900x900');
+  });
+
+  it('picks the resolution that minimises |Δw| + |Δh| for a custom target', () => {
+    const target = { width: 1920, height: 1080 };
+    const candidates = ['1280x720', '2560x1440', '1920x1080'];
+    expect(getBestResolution(candidates, target)).toBe('1920x1080');
+  });
+
+  it('breaks ties predictably (first with equal error wins)', () => {
+    const target = { width: 1000, height: 1000 };
+    const candidates = ['900x1100', '1100x900']; // both error = 200
+    expect(getBestResolution(candidates, target)).toBe('900x1100');
+  });
+});

--- a/components/verification-camera/resolution.tsx
+++ b/components/verification-camera/resolution.tsx
@@ -1,0 +1,58 @@
+type Resolution = { width: number; height: number };
+
+const parseResolution = (resolutionText: string): Resolution | null => {
+  if (!/^\d+x\d+$/.test(resolutionText)) {
+    return null;
+  }
+
+  const [horizontalText, verticalText] = resolutionText.split("x");
+  const width = Number(horizontalText);
+  const height = Number(verticalText);
+
+  return Number.isFinite(width) && Number.isFinite(height)
+    ? { width, height }
+    : null;
+};
+
+const error = (a: Resolution, b: Resolution) => {
+  return Math.abs(a.height - b.height) + Math.abs(a.width - b.width);
+};
+
+const comparator = (target: Resolution) => (a: Resolution, b: Resolution) => {
+  const errorA = error(target, a);
+  const errorB = error(target, b);
+
+  if (errorA > errorB) {
+    return 1;
+  } else if (errorA < errorB) {
+    return -1;
+  } else {
+    return 0;
+  }
+};
+
+const getBestResolution = (
+  resolutionTexts: string[] | null | undefined,
+  targetResolution: Resolution = { height: 900, width: 900 },
+): string | null => {
+  if (!resolutionTexts) {
+    return null;
+  }
+
+  const parsedResolutions = resolutionTexts
+    .map(parseResolution)
+    .filter((candidate): candidate is Resolution => candidate !== null);
+
+  parsedResolutions.sort(comparator(targetResolution));
+
+  if (parsedResolutions.length === 0) {
+    return null;
+  } else {
+    const bestResolution = parsedResolutions[0];
+    return `${bestResolution.width}x${bestResolution.height}`;
+  }
+};
+
+export {
+  getBestResolution,
+};

--- a/data/option-groups.tsx
+++ b/data/option-groups.tsx
@@ -1,5 +1,5 @@
 import * as _ from "lodash";
-import { api, japi, ApiResponse } from '../api/api';
+import { japi, ApiResponse } from '../api/api';
 import { setSignedInUser, navigationContainerRef } from '../App';
 import { sessionToken, sessionPersonUuid } from '../kv-storage/session-token';
 import { X } from "react-native-feather";
@@ -32,6 +32,7 @@ import {
 } from 'react-native';
 import { FC } from 'react';
 import { onboardingQueue } from '../api/queue';
+import { showVerificationCamera } from '../components/verification-camera';
 
 const noneFontSize = 16;
 
@@ -119,12 +120,6 @@ type OptionGroupCheckChips = {
   }
 };
 
-type OptionGroupVerificationCamera = {
-  verificationCamera: {
-    submit: (base64: string) => Promise<boolean>
-  }
-};
-
 type OptionGroupVerificationChecker = {
   verificationChecker: {}
 };
@@ -190,7 +185,6 @@ type OptionGroupInputs
   | OptionGroupTextShort
   | OptionGroupOtp
   | OptionGroupCheckChips
-  | OptionGroupVerificationCamera
   | OptionGroupVerificationChecker
   | OptionGroupThemePicker
   | OptionGroupNone;
@@ -202,7 +196,6 @@ type OptionGroup<T extends OptionGroupInputs> = {
   input: T,
   scrollView?: boolean,
   buttonLabel?: string,
-  fullScreen?: boolean,
 };
 
 const hasExactKeys = (obj, keys) => {
@@ -256,10 +249,6 @@ const isOptionGroupTextShort = (x: any): x is OptionGroupTextShort => {
 
 const isOptionGroupOtp = (x: any): x is OptionGroupOtp => {
   return hasExactKeys(x, ['otp']);
-}
-
-const isOptionGroupVerificationCamera = (x: any): x is OptionGroupVerificationCamera => {
-  return hasExactKeys(x, ['verificationCamera']);
 }
 
 const isOptionGroupVerificationChecker = (x: any): x is OptionGroupVerificationChecker => {
@@ -1942,47 +1931,10 @@ const verificationOptionGroups: OptionGroup<OptionGroupInputs>[] = [
       none: {
         description: verificationDescription,
         textAlign: 'left',
-        submit: async () => true,
-      }
-    }
-  },
-  {
-    title: 'Get Verified',
-    description: `Press ‘Continue’ to submit your selfie.`,
-    fullScreen: true,
-    input: {
-      verificationCamera: {
-        submit: async (base64) => {
-          const response1 = await japi(
-            'post',
-            '/verification-selfie',
-            {
-              base64_file: {
-                position: 1,
-                base64,
-                top: 0,
-                left: 0,
-              },
-            },
-            {
-              timeout: 2 * 60 * 1000, // 2 minutes
-              showValidationToast: true,
-            }
-          );
-
-          if (!response1.ok) {
-            return false;
-          }
-
-          const response2 = await api(
-            'post', '/verify', undefined, { maxRetries: 0 });
-
-          if (!response2.ok) {
-            return false;
-          }
-
+        submit: async () => {
+          showVerificationCamera(true);
           return true;
-        }
+        },
       }
     }
   },
@@ -2011,7 +1963,6 @@ export {
   OptionGroupTextLong,
   OptionGroupTextShort,
   OptionGroupThemePicker,
-  OptionGroupVerificationCamera,
   OptionGroupVerificationChecker,
   basicsOptionGroups,
   createAccountOptionGroups,
@@ -2033,7 +1984,6 @@ export {
   isOptionGroupTextLong,
   isOptionGroupTextShort,
   isOptionGroupThemePicker,
-  isOptionGroupVerificationCamera,
   isOptionGroupVerificationChecker,
   maxDailySelfies,
   noneFontSize,

--- a/data/option-groups.tsx
+++ b/data/option-groups.tsx
@@ -20,7 +20,6 @@ import { NonNullImageCropperOutput } from '../components/image-cropper';
 import { login, logout } from '../chat/application-layer';
 import { LOGARITHMIC_SCALE, Scale } from "../scales/scales";
 import { VerificationBadge } from '../components/verification-badge';
-import { VerificationEvent } from '../verification/verification';
 import { notify } from '../events/events';
 import { ClubItem } from '../club/club';
 import { DefaultText } from '../components/default-text';
@@ -32,7 +31,10 @@ import {
 } from 'react-native';
 import { FC } from 'react';
 import { onboardingQueue } from '../api/queue';
-import { showVerificationCamera } from '../components/verification-camera';
+import {
+  notifyUpdatedVerification,
+  showVerificationCamera,
+} from '../components/verification-camera';
 
 const noneFontSize = 16;
 
@@ -573,7 +575,7 @@ const genderOptionGroup: OptionGroup<OptionGroupButtons> = {
         const ok = (await japi('patch', '/profile-info', { gender })).ok;
         if (ok) {
           this.currentValue = gender;
-          notify<VerificationEvent>('updated-verification', { gender: false });
+          notifyUpdatedVerification({ gender: false });
         }
         return ok;
       },
@@ -607,7 +609,7 @@ const ethnicityOptionGroup: OptionGroup<OptionGroupButtons> = {
         const ok = (await japi('patch', '/profile-info', { ethnicity })).ok;
         if (ok) {
           this.currentValue = ethnicity;
-          notify<VerificationEvent>('updated-verification', { ethnicity: false });
+          notifyUpdatedVerification({ ethnicity: false });
         }
         return ok;
       },

--- a/data/option-groups.tsx
+++ b/data/option-groups.tsx
@@ -31,10 +31,8 @@ import {
 } from 'react-native';
 import { FC } from 'react';
 import { onboardingQueue } from '../api/queue';
-import {
-  notifyUpdatedVerification,
-  showVerificationCamera,
-} from '../components/verification-camera';
+import { showVerificationCamera } from '../components/verification-camera';
+import { notifyUpdatedVerification } from '../verification/verification';
 
 const noneFontSize = 16;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "30.1.1",
       "dependencies": {
         "@expo/metro-runtime": "~5.0.4",
-        "@expo/vector-icons": "^14.1.0",
         "@fortawesome/fontawesome-svg-core": "^6.6.0",
         "@fortawesome/free-solid-svg-icons": "^6.6.0",
         "@fortawesome/react-native-fontawesome": "^0.3.2",
@@ -21,6 +20,7 @@
         "date-fns": "^2.30.0",
         "expo": "53.0.9",
         "expo-av": "~15.1.4",
+        "expo-camera": "~16.1.6",
         "expo-checkbox": "~4.1.4",
         "expo-clipboard": "~7.1.4",
         "expo-constants": "~17.1.6",
@@ -8598,6 +8598,25 @@
       "version": "15.1.4",
       "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.1.4.tgz",
       "integrity": "sha512-p+U5Hl89i8QQN7uATcUX2Fc9wT5FQcQkvuv43Qwbpi6hUSSjLgVWkXxThDMolqOFDOOsKWM/UM6pmex4XP+uSw==",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*",
+        "react-native-web": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-web": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/expo-camera": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.6.tgz",
+      "integrity": "sha512-caVSfoTUaayYhH5gicrXWCgBQIVrotPOH3jUDr4vhN5VQDB/+TWaY+le2nQtNXgQEz14Af+H/TNvYpvvNj5Ktg==",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
       "peerDependencies": {
         "expo": "*",
         "react": "*",
@@ -24181,6 +24200,14 @@
       "resolved": "https://registry.npmjs.org/expo-av/-/expo-av-15.1.4.tgz",
       "integrity": "sha512-p+U5Hl89i8QQN7uATcUX2Fc9wT5FQcQkvuv43Qwbpi6hUSSjLgVWkXxThDMolqOFDOOsKWM/UM6pmex4XP+uSw==",
       "requires": {}
+    },
+    "expo-camera": {
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-16.1.6.tgz",
+      "integrity": "sha512-caVSfoTUaayYhH5gicrXWCgBQIVrotPOH3jUDr4vhN5VQDB/+TWaY+le2nQtNXgQEz14Af+H/TNvYpvvNj5Ktg==",
+      "requires": {
+        "invariant": "^2.2.4"
+      }
     },
     "expo-checkbox": {
       "version": "4.1.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "@expo/metro-runtime": "~5.0.4",
-    "@expo/vector-icons": "^14.1.0",
     "@fortawesome/fontawesome-svg-core": "^6.6.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@fortawesome/react-native-fontawesome": "^0.3.2",
@@ -33,6 +32,7 @@
     "date-fns": "^2.30.0",
     "expo": "53.0.9",
     "expo-av": "~15.1.4",
+    "expo-camera": "~16.1.6",
     "expo-checkbox": "~4.1.4",
     "expo-clipboard": "~7.1.4",
     "expo-constants": "~17.1.6",


### PR DESCRIPTION
This is the first in a series of PRs which will make verification less prone to spoofing. The current road map includes these milestones:

* Allow submissions via the camera rather than file upload (this PR)
* Add liveness checks (if necessary)
* Require verification for UK users by the deadline

---

TODO:

- [ ] Pick a moderate resolution, close to 720p with an aspect ratio near 1:1
- [ ] Camera's close button should go back
- [ ] Ensure images are send with the right cropping and aspect ratio
- [ ] Test the removal of `@expo/vector-icons` didn't break font awesome or feather icons
- [ ] Ellipsis doesn't animate on "Uploading photo..." status
- [ ] Allow the user to go back if they don't grant permissions

---

Notes:

- According to expo's performance monitor, the camera takes 223.14 - 218.08 = 5.01 MB of RAM on iOS. I'm sceptical.