### PR TITLE
react-native-reanimated@3.18.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "react-native-dropdown-picker": "^5.4.4",
         "react-native-feather": "^1.1.2",
         "react-native-gesture-handler": "~2.24.0",
-        "react-native-reanimated": "~3.17.4",
+        "react-native-reanimated": "^3.18.0",
         "react-native-safe-area-context": "5.4.0",
         "react-native-screens": "~4.10.0",
         "react-native-svg": "15.11.2",
@@ -14970,9 +14970,9 @@
       }
     },
     "node_modules/react-native-reanimated": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
-      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.18.0.tgz",
+      "integrity": "sha512-eVcNcqeOkMW+BUWAHdtvN3FKgC8J8wiEJkX6bNGGQaLS7m7e4amTfjIcqf/Ta+lerZLurmDaQ0lICI1CKPrb1Q==",
       "dependencies": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",
@@ -28784,9 +28784,9 @@
       "requires": {}
     },
     "react-native-reanimated": {
-      "version": "3.17.5",
-      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.17.5.tgz",
-      "integrity": "sha512-SxBK7wQfJ4UoWoJqQnmIC7ZjuNgVb9rcY5Xc67upXAFKftWg0rnkknTw6vgwnjRcvYThrjzUVti66XoZdDJGtw==",
+      "version": "3.18.0",
+      "resolved": "https://registry.npmjs.org/react-native-reanimated/-/react-native-reanimated-3.18.0.tgz",
+      "integrity": "sha512-eVcNcqeOkMW+BUWAHdtvN3FKgC8J8wiEJkX6bNGGQaLS7m7e4amTfjIcqf/Ta+lerZLurmDaQ0lICI1CKPrb1Q==",
       "requires": {
         "@babel/plugin-transform-arrow-functions": "^7.0.0-0",
         "@babel/plugin-transform-class-properties": "^7.0.0-0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "react-native-dropdown-picker": "^5.4.4",
     "react-native-feather": "^1.1.2",
     "react-native-gesture-handler": "~2.24.0",
-    "react-native-reanimated": "~3.17.4",
+    "react-native-reanimated": "^3.18.0",
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.10.0",
     "react-native-svg": "15.11.2",


### PR DESCRIPTION
There seem to have been more crashes in production since https://github.com/duolicious/duolicious-frontend/pull/767 was released, especially on iOS. Judging by the production logs in Google Play (Duolicious has no iOS logging), I think this issue was fixed in https://github.com/software-mansion/react-native-reanimated/pull/7515, which is in react-native-reanimated@3.18.0.

---

I'm seeing this:

```
 ERROR  [runtime not ready]: ReanimatedError: [Reanimated] Mismatch between JavaScript part and native part of Reanimated (3.18.0 vs 3.17.4).                                                                                     
    See `https://docs.swmansion.com/react-native-reanimated/docs/guides/troubleshooting#mismatch-between-javascript-part-and-native-part-of-reanimated` for more details., js engine: hermes
› Stopped server 
```

The docs say it's likely because a dependency is using 3.17.4 worklets. Though I don't see any dependencies which require that. It might be an issue with expo, which includes these errors when starting:

```
The following packages should be updated for best compatibility with the installed expo version:
  react-native-reanimated@3.18.0 - expected version: ~3.17.4
  react-native-screens@4.10.0 - expected version: ~4.11.1
Your project may not work correctly until you install the expected versions of the packages.
```