### PR TITLE
Fix issue with too many donations

### DIFF
--- a/components/utility-screen.tsx
+++ b/components/utility-screen.tsx
@@ -30,20 +30,14 @@ const useHasDonations = (estimatedEndDate: Date | undefined) => {
       return;
     }
 
-    const now = new Date();
-    const timeUntilEnd = estimatedEndDate.getTime() - now.getTime();
+    const update = () => {
+      setHasDonations(Date.now() < estimatedEndDate.getTime());
+    };
 
-    if (timeUntilEnd <= 0) {
-      setHasDonations(false);
-      return;
-    }
+    update(); // ensure immediate correctness
 
-    // Set a timer to update when the date is no longer in the future
-    const timer = setTimeout(() => {
-      setHasDonations(false);
-    }, timeUntilEnd);
-
-    return () => clearTimeout(timer); // Clean up the timer if the date changes
+    const interval = setInterval(update, 60_000); // check every minute
+    return () => clearInterval(interval);
   }, [estimatedEndDate]);
 
   return hasDonations;


### PR DESCRIPTION
An integer overflow issue can allow an attacker to bring down Duolicious by giving a month's worth of donations. Thankfully, we've never received this much.