### PR TITLE
API version 6

### DIFF
--- a/api/api.tsx
+++ b/api/api.tsx
@@ -8,10 +8,10 @@ import { notify } from '../events/events';
 import { ValidationErrorToast, SOMETHING_WENT_WRONG } from '../components/toast';
 
 const SUPPORTED_API_VERSIONS = [
-  5,
   6,
-  500_000,
   600_000,
+  7,
+  700_000,
 ];
 
 type ApiResponse = {


### PR DESCRIPTION
https://status.duolicious.app/ now yields:

```json
{ "api_version": 6, "statuses": [ "ok", "down for maintenance" ], "status_index": 0 }
```

Support for API v5 is deprecated.

`7` and `700_000` have been added to `SUPPORTED_API_VERSIONS` to support future upgrades.