### PR TITLE
Fix button flicker

### DIFF
--- a/animation/animation.tsx
+++ b/animation/animation.tsx
@@ -58,8 +58,8 @@ const usePressableAnimation = () => {
   const onPressIn = useCallback(() => {
     Animated.timing(animatedBackgroundColor, {
       toValue: 1,
-      duration: 100,
-      useNativeDriver: false,
+      duration: 0,
+      useNativeDriver: true,
     }).start();
   }, []);
 
@@ -67,7 +67,7 @@ const usePressableAnimation = () => {
     Animated.timing(animatedBackgroundColor, {
       toValue: 0,
       duration: 150,
-      useNativeDriver: false,
+      useNativeDriver: true,
     }).start();
   }, []);
 

--- a/components/navigation/tab-bar.tsx
+++ b/components/navigation/tab-bar.tsx
@@ -25,7 +25,7 @@ const Tab = ({ navigation, state, route, descriptors, index, numUnread }) => {
     Animated.timing(animated, {
       toValue: 1,
       duration: 500,
-      useNativeDriver: false,
+      useNativeDriver: true,
     }).start();
   };
 


### PR DESCRIPTION
Buttons which use `usePressableAnimation` to animate their presses can flicker when the user releases the button very shortly after pressing it.