### PR TITLE
Clarify email rejection message

### DIFF
--- a/components/welcome-screen.tsx
+++ b/components/welcome-screen.tsx
@@ -469,7 +469,7 @@ const WelcomeScreen_ = ({navigation, route}) => {
       );
     } else {
       setLoginStatus(
-        response.status === 400 ? 'We don’t support that email provider' :
+        response.status === 400 ? 'We don’t support that email domain' :
         response.status === 429 ? 'You’re doing that too much' :
         response.status === 460 ? 'Network blocked. Are you using a VPN?' :
         response.status === 461 ? 'Your account is banned' :


### PR DESCRIPTION
"We don't support that email provider" is misleading, because the rejection actually is based on the domain: a person using Gmail as the provider for his "firstnamelastname at firstnamelastname dot com" email address still will be rejected.