### PR TITLE
Only detach on iOS

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -87,7 +87,7 @@ const HomeTabs = () => {
       // Without this, tabs appear blank about 5% of the time when switching
       // between them. ChatGPT suggests the react-native-screens and
       // bottom-tabs animation packages are racing to detach the screens.
-      detachInactiveScreens={false}
+      detachInactiveScreens={Platform.OS !== 'ios'}
     >
       <Tab.Screen name="Q&A" component={QuizTab} options={{ title: 'Q&A' }} />
       <Tab.Screen name="Search" component={SearchTab} options={{ title: 'Search' }} />


### PR DESCRIPTION
This mitigates a performance degradation introduced in https://github.com/duolicious/duolicious-frontend/pull/977.

I can only reliably reproduce the issue on iOS, and keeping the screens attached causes performance degradation on Android.