### PR TITLE
Conversation text input is occluded by the keyboard on Android

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -57,6 +57,7 @@ import { isMobile } from './util/util';
 import { Logo16 } from './components/logo';
 import { useScrollbarStyle } from './components/navigation/scroll-bar-hooks';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import { KeyboardProvider } from 'react-native-keyboard-controller';
 import { ErrorBoundary } from './components/error-boundary';
 import { TooltipListener } from './components/tooltip';
 import { VerificationCameraModal } from './components/verification-camera';
@@ -662,6 +663,7 @@ const App = () => {
       <SafeAreaProvider>
         {!isLoading && initialState !== undefined &&
           <GestureHandlerRootView>
+            <KeyboardProvider>
             <NavigationContainer
               ref={navigationContainerRef}
               linking={linking}
@@ -727,6 +729,7 @@ const App = () => {
             <Toast/>
             <PointOfSaleModal/>
             <VerificationCameraModal/>
+            </KeyboardProvider>
           </GestureHandlerRootView>
         }
         <SplashScreen loading={isLoading} />

--- a/components/conversation-screen/conversation-screen.tsx
+++ b/components/conversation-screen/conversation-screen.tsx
@@ -892,7 +892,7 @@ const ConversationScreen = ({navigation, route}) => {
             fontFamily: 'Trueno',
           }}
         >
-          This person isn't available right now. This often means their account
+          This person isn’t available right now. This often means their account
           is inactive or was deleted.
         </DefaultText>
       }

--- a/components/conversation-screen/input.tsx
+++ b/components/conversation-screen/input.tsx
@@ -6,12 +6,12 @@ import {
   useReducer,
 } from 'react';
 import {
-  KeyboardAvoidingView,
   Platform,
   StyleSheet,
   View,
   useWindowDimensions,
 } from 'react-native';
+import { KeyboardAvoidingView } from 'react-native-keyboard-controller';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -770,7 +770,7 @@ const Input = ({
   const finalGesture = Gesture.Exclusive(tapGesture, combinedGesture);
 
   return (
-    <KeyboardAvoidingView enabled={Platform.OS === 'ios'} behavior="padding">
+    <KeyboardAvoidingView behavior="padding">
       <QuotePreview quote={quote} />
       <View style={styles.container} onLayout={onLayout}>
         {/* Input wrapper: position relative so we can overlay the cancel overlay */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,6 +51,7 @@
         "react-native-feather": "^1.1.2",
         "react-native-gesture-handler": "~2.30.0",
         "react-native-get-random-values": "^1.11.0",
+        "react-native-keyboard-controller": "1.20.7",
         "react-native-purchases": "^9.2.2",
         "react-native-reanimated": "^4.3.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -15648,6 +15649,20 @@
         "react-native": "*"
       }
     },
+    "node_modules/react-native-keyboard-controller": {
+      "version": "1.20.7",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.20.7.tgz",
+      "integrity": "sha512-G8S5jz1FufPrcL1vPtReATx+jJhT/j+sTqxMIb30b1z7cYEfMlkIzOCyaHgf6IMB2KA9uBmnA5M6ve2A9Ou4kw==",
+      "license": "MIT",
+      "dependencies": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      },
+      "peerDependencies": {
+        "react": "*",
+        "react-native": "*",
+        "react-native-reanimated": ">=3.0.0"
+      }
+    },
     "node_modules/react-native-purchases": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/react-native-purchases/-/react-native-purchases-9.2.2.tgz",
@@ -29096,6 +29111,14 @@
       "resolved": "https://registry.npmjs.org/react-native-is-edge-to-edge/-/react-native-is-edge-to-edge-1.3.1.tgz",
       "integrity": "sha512-NIXU/iT5+ORyCc7p0z2nnlkouYKX425vuU1OEm6bMMtWWR9yvb+Xg5AZmImTKoF9abxCPqrKC3rOZsKzUYgYZA==",
       "requires": {}
+    },
+    "react-native-keyboard-controller": {
+      "version": "1.20.7",
+      "resolved": "https://registry.npmjs.org/react-native-keyboard-controller/-/react-native-keyboard-controller-1.20.7.tgz",
+      "integrity": "sha512-G8S5jz1FufPrcL1vPtReATx+jJhT/j+sTqxMIb30b1z7cYEfMlkIzOCyaHgf6IMB2KA9uBmnA5M6ve2A9Ou4kw==",
+      "requires": {
+        "react-native-is-edge-to-edge": "^1.2.1"
+      }
     },
     "react-native-purchases": {
       "version": "9.2.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "react-native-feather": "^1.1.2",
     "react-native-gesture-handler": "~2.30.0",
     "react-native-get-random-values": "^1.11.0",
+    "react-native-keyboard-controller": "1.20.7",
     "react-native-purchases": "^9.2.2",
     "react-native-reanimated": "^4.3.1",
     "react-native-safe-area-context": "~5.6.0",


### PR DESCRIPTION
Fixes https://github.com/duolicious/duolicious-frontend/issues/979. While I didn't thoroughly check, according to this discussion (https://github.com/orgs/community/discussions/167709), it was probably broken by an Expo SDK upgrade. The linked discussion says SDK 53 broke it. But for Duolicious, I think the trouble was probably the upgrade to _54_ (https://github.com/duolicious/duolicious-frontend/pull/965).

## Alternatives I considered

I tried to avoid adding a dependency to fix this, but React Native's own [`KeyboardAvoidingView`](https://reactnative.dev/docs/keyboardavoidingview) is notoriously flaky.

* Something I considered was to implement our own keyboard-avoiding component using react-native-reanimated, which is already a dependency. But doing so would require the use of `useAnimatedKeyboard`, which Reanimated's own [documentation](https://docs.swmansion.com/react-native-reanimated/docs/device/useAnimatedKeyboard/#migration-guide) says was "deprecated due to persistent bugs on iOS 26".
* Simply disabling the `KeyboardAvoidingView` on Android and resizing the screen isn't an option. It used to be the default in earlier versions of Android, but I understand that's changed with more recent versions and [edge-to-edge design](https://developer.android.com/design/ui/mobile/guides/layout-and-content/edge-to-edge), which is mandatory in some versions of Android now.
* Another dependency Duolicious already uses, `react-native-safe-area-context`'s doesn't seem to provide any information about the presence/position of the keyboard.